### PR TITLE
Add setup script for toolchains

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# install toolchains with pinned versions; safe to run multiple times
+PYTHON_VERSION=3.11
+NODE_VERSION=20
+
+have_python() {
+  command -v python3 >/dev/null 2>&1 && python3 -V | grep -q "$PYTHON_VERSION"
+}
+
+have_node() {
+  command -v node >/dev/null 2>&1 && node -v | grep -q "v$NODE_VERSION"
+}
+
+if ! have_python; then
+  echo "Installing Python $PYTHON_VERSION" >&2
+  sudo apt-get update -y
+  sudo apt-get install -y software-properties-common >/dev/null
+  sudo add-apt-repository -y ppa:deadsnakes/ppa
+  sudo apt-get update -y
+  sudo apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-venv
+  sudo ln -sf /usr/bin/python${PYTHON_VERSION} /usr/local/bin/python3
+fi
+
+if ! have_node; then
+  echo "Installing Node.js $NODE_VERSION" >&2
+  curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x | sudo -E bash -
+  sudo apt-get install -y nodejs
+fi
+
+echo "Setup complete"
+exit 0

--- a/NOTES.md
+++ b/NOTES.md
@@ -25,3 +25,8 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: establish collaboration conventions before code.
 - **Next step**: set up lint/test commands and begin core feature A.
 
+## 2025-07-13  PR #draft
+- **Summary**: added setup script for Python and Node and updated README.
+- **Stage**: implementation
+- **Motivation / Decision**: needed bootstrap to install toolchains idempotently.
+- **Next step**: define lint and test commands.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # PoseDetection
 realtime Human Pose Estimation System
+
+## Setup
+
+Run `.codex/setup.sh` after cloning to install Python 3.11 and Node 20.
+The script is idempotent and exits 0 when finished.

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@
 ## 0 · Project bootstrap
 - [ ] Commit starter governance files (`AGENTS.md`, `TODO.md`, `NOTES.md`,
       minimal CI)
-- [ ] Add `.codex/setup.sh`; ensure it is idempotent and exits 0
+- [x] Add `.codex/setup.sh`; ensure it is idempotent and exits 0
 - [ ] Configure `make lint` and `make test` (cover every language tool‑chain)
 - [ ] Audit repository & docs; identify the single source of truth
       (spec, assignment …) and reference it in README


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` for bootstrapping Python and Node
- note setup instructions in README
- log the change in NOTES and tick TODO

## Testing
- `make lint` *(fails: No rule to make target 'lint')*
- `make test` *(fails: No rule to make target 'test')*
- `.codex/setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6873bba3319883259c408145c896885e