### PR TITLE
chore: add initial Python and Node manifests

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -60,3 +60,9 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: repo already includes `AGENTS.md`, `TODO.md`,
   `NOTES.md` so the item was marked as done.
 - **Next step**: add setup script and define lint/test commands.
+
+## 2025-07-13  PR #3
+- **Summary**: added pinned dependency manifests for Python and Node.
+- **Stage**: implementation
+- **Motivation / Decision**: follow roadmap item for reproducible setups.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@
 - [x] Add `.codex/setup.sh`; ensure it is idempotent and exits 0
 
 
-- [ ] Generate initial dependency manifests (`requirements.txt`,
+- [x] Generate initial dependency manifests (`requirements.txt`,
       `package.json`, `pubspec.yaml`, …) with pinned versions
 - [ ] Define ownership of all generated code in `/generated/**` and record the
       regeneration command in `AGENTS.md`

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "posedetection-ui",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.4.0"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.116.1
+uvicorn[standard]==0.35.0
+opencv-python==4.12.0.88
+mediapipe==0.10.21


### PR DESCRIPTION
## Summary
- pin dependencies in `requirements.txt`
- add minimal React/TypeScript `package.json`
- mark roadmap item done
- log the work in `NOTES.md`

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6873c2f9cec48325b3fd2c9a433530f7