### PR TITLE
Add placeholder test suite

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -60,3 +60,10 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: repo already includes `AGENTS.md`, `TODO.md`,
   `NOTES.md` so the item was marked as done.
 - **Next step**: add setup script and define lint/test commands.
+
+### 2025-07-13  PR #3
+- **Summary**: added placeholder tests to keep CI green.
+- **Stage**: implementation
+- **Motivation / Decision**: needed a simple test so CI
+  succeeds before features exist.
+- **Next step**: prepare feature A implementation.

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,0 +1,4 @@
+import pytest
+
+def test_placeholder():
+    assert True


### PR DESCRIPTION
## Summary
- add placeholder `tests/` directory with one passing test
- document reasoning for placeholder suite in NOTES

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6873c2fb903c83258b34811df511bdcf