### PR TITLE
docs: timestamp TODO roadmap header

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -60,3 +60,9 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: repo already includes `AGENTS.md`, `TODO.md`,
   `NOTES.md` so the item was marked as done.
 - **Next step**: add setup script and define lint/test commands.
+
+## 2025-07-13  PR #3
+- **Summary**: timestamped TODO roadmap header.
+- **Stage**: documentation
+- **Motivation / Decision**: keep roadmap current.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO – Road‑map  (last updated: YYYY‑MM‑DD)
+# TODO – Road‑map  (last updated: 2025-07-13)
 
 > *Record only high‑level milestones here; break micro‑tasks out into Issues.*  
 > **When you finish a task, tick it and append a short NOTE entry
@@ -54,3 +54,4 @@
 
 ### Add new items below this line  
 *(append only; keep earlier history intact)*
+- [ ] Automate updating the TODO header date whenever tasks change.


### PR DESCRIPTION
## Summary
- timestamp TODO roadmap header with today's date
- note the change in NOTES.md
- add a TODO item about automating the date update

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6873c2f746e88325aef9651d481f3441