### PR TITLE
docs: clean up README tagline duplication

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -60,3 +60,9 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: repo already includes `AGENTS.md`, `TODO.md`,
   `NOTES.md` so the item was marked as done.
 - **Next step**: add setup script and define lint/test commands.
+
+## 2025-07-13  PR #3
+- **Summary**: removed duplicate tagline line in README.
+- **Stage**: documentation
+- **Motivation / Decision**: keep README concise.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ cd PoseDetection
 make lint
 make test
 ```
-realtime Human Pose Estimation System
 
 ## Development
 Run `make lint` to check documentation style.

--- a/TODO.md
+++ b/TODO.md
@@ -54,3 +54,4 @@
 
 ### Add new items below this line  
 *(append only; keep earlier history intact)*
+- [x] Remove duplicate tagline from README


### PR DESCRIPTION
## Summary
- remove the second occurrence of the tagline in README
- log the update in NOTES
- track the change in TODO

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6873c2f4d74483258a816a5bc2126b15