### PR TITLE
docs: fix typo in AGENTS guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ---
 Always follow single source of truth.
-Always do as specified in signle source of truth.
+Always do as specified in single source of truth.
 If something is not specified in single source of truth - choose simplest safest options.
 Implement project as specified in TODO.md. Reflect on progress in NOTES.md.
 When any issue in codex environment happens, always suggest additions/modifications to this AGENTS.md to prevent such issues in future.

--- a/NOTES.md
+++ b/NOTES.md
@@ -60,3 +60,9 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: repo already includes `AGENTS.md`, `TODO.md`,
   `NOTES.md` so the item was marked as done.
 - **Next step**: add setup script and define lint/test commands.
+
+## 2025-07-13  PR #3
+- **Summary**: fixed typo in AGENTS guide.
+- **Stage**: documentation
+- **Motivation / Decision**: keep contributor guide accurate.
+- **Next step**: none.


### PR DESCRIPTION
## Summary
- fix a typo in AGENTS.md
- log the change in NOTES.md

## Testing
- `npx --yes markdownlint-cli '**/*.md'` *(fails: MD013 line length etc.)*
- `make test` *(prints `No tests yet`)*

------
https://chatgpt.com/codex/tasks/task_e_6873c2f310c083258f228b3e12b9ec1d