### PR TITLE
Update docs-only lint step note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide  <!-- AGENTS.md v1.1 -->
+# Contributor & CI Guide  <!-- AGENTS.md v1.2 -->
 
 > **Read this file first** before opening a pull‑request.  
 > It defines the ground rules that keep humans, autonomous agents and CI in‑sync.  
@@ -36,11 +36,12 @@ Maintain and develop the project so that after each new feature user will be abl
 ## 3 · What every contributor must know up‑front
 
 1. **Branch & PR flow** – fork → `feat/<topic>` → PR into `main` (one reviewer required).  
-2. **Pre‑commit commands** (also run by CI):  
+2. **Pre‑commit commands** (also run by CI):
    ```bash
    make lint                  # all format / static‑analysis steps
    make test                  # project’s unit‑/integration tests
    ```
+   - For docs-only changes run `make lint` (or `make lint-docs`) before committing.
 3. **Style rules** – keep code formatted (`black`, `prettier`, `dart format`, etc.) and Markdown lines ≤ 80 chars; exactly **one blank line** separates log entries.  
 4. **Exit‑code conventions** – scripts must exit ≠ 0 on failure so CI catches regressions (e.g. fail fast when quality gates or metric thresholds aren’t met).  
 5. **Version‑pin policy** – pin *major*/*minor* versions for critical runtimes & actions (e.g. `actions/checkout@v4`, `node@20`, `python~=3.11`).  

--- a/NOTES.md
+++ b/NOTES.md
@@ -88,3 +88,9 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Stage**: implementation
 - **Motivation / Decision**: follow roadmap item for reproducible setups.
 - **Next step**: none.
+
+## 2025-07-13  PR #8
+- **Summary**: bumped AGENTS.md to v1.2 and clarified docs-only lint command.
+- **Stage**: documentation
+- **Motivation / Decision**: keep guide current so contributors know to run local lint.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -56,3 +56,4 @@
 *(append only; keep earlier history intact)*
 - [x] Remove duplicate tagline from README
 - [ ] Automate updating the TODO header date whenever tasks change.
+- [x] Document local docs-only linting in AGENTS guide.


### PR DESCRIPTION
## Summary
- bump AGENTS header to v1.2
- mention `make lint` for docs-only changes
- record the update in NOTES and TODO

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6873c623e48c8325874e4e397723eede