### PR TITLE
Fix README heading spacing

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -94,3 +94,9 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Stage**: documentation
 - **Motivation / Decision**: keep guide current so contributors know to run local lint.
 - **Next step**: none.
+
+## 2025-07-13  PR #9
+- **Summary**: inserted blank line after the Development heading in README.
+- **Stage**: documentation
+- **Motivation / Decision**: follow lint rules; fix markdownlint MD022 error.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ make test
 ```
 
 ## Development
+
 Run `make lint` to check documentation style.
 Run `make test` to execute the future test-suite.
 


### PR DESCRIPTION
## Summary
- add missing blank line after the Development heading
- document the change in NOTES

## Testing
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_6873cedd569c8325b025718362247177