### PR TITLE
docs: clarify conflict marker escaping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           npx --yes markdownlint-cli '**/*.md'
-          grep -R --line-number -E '<<<<<<<|=======|>>>>>>>' . && exit 1 || echo "No conflict markers"
+          pattern="<""<""<""<""<""<""<""|""=""=""=""=""=""=""=""|"">"">"">"">"">"">"">"
+          grep -R --line-number -E "$pattern" . && exit 1 || echo "No conflict markers"
 
   test:
     needs: [changes]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.3 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.4 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -28,7 +28,9 @@ and run in local IDE to test manually.
 - **Generated-files rule** – Anything under `generated/**` or `openapi/**` is
   code-generated—never hand-edit; instead rerun the generator.
 - **Search for conflict markers before every commit** –
-  `git grep -n '<<<<<<<\|=======\|>>>>>>>'` must return nothing.
+`git grep -n '&lt;&lt;&lt;&lt;&lt;&lt;&lt;\|&#61;&#61;&#61;&#61;&#61;&#61;&#61;\|&gt;&gt;&gt;&gt;&gt;&gt;&gt;'` must return nothing.
+- **Escape conflict markers in docs** – write them as
+  `&lt;&lt;&lt;&lt;&lt;&lt;&lt;`, `&#61;&#61;&#61;&#61;&#61;&#61;&#61;`, `&gt;&gt;&gt;&gt;&gt;&gt;&gt;` to avoid false positives.
 
 ---
 
@@ -115,7 +117,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           npx --yes markdownlint-cli '**/*.md'
-          grep -R --line-number -E '<<<<<<<|=======|>>>>>>>' . && exit 1 || echo "No conflict markers"
+        grep -R --line-number -E '&lt;&lt;&lt;&lt;&lt;&lt;&lt;|&#61;&#61;&#61;&#61;&#61;&#61;&#61;|&gt;&gt;&gt;&gt;&gt;&gt;&gt;' . && exit 1 || echo "No conflict markers"
 
   test:
     needs: [changes]

--- a/NOTES.md
+++ b/NOTES.md
@@ -145,3 +145,10 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: enforce consistent markdown
   and prevent future lint errors.
 - **Next step**: none.
+
+## 2025-07-14  PR #12
+
+- **Summary**: bumped AGENTS to v1.4, escaped conflict markers and updated CI.
+- **Stage**: documentation
+- **Motivation / Decision**: avoid false positives from grep rule.
+- **Next step**: none.


### PR DESCRIPTION
## Summary
- bump AGENTS guide to v1.4
- escape conflict marker strings and add guidance
- tweak CI step to build grep pattern at runtime
- log update in NOTES

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68749e9def0c83258520c87c0b1edd19