### PR TITLE
Update docs: conflict marker quoting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.4 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.5 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -29,6 +29,9 @@ and run in local IDE to test manually.
   code-generated—never hand-edit; instead rerun the generator.
 - **Search for conflict markers before every commit** –
   `git grep -n -E '<{7}|={7}|>{7}'` must return nothing.
+- **Never include literal conflict markers in docs** –
+  use the `<{7}` notation (and similar) when referencing
+  `<<<<<<<`, `=======` or `>>>>>>>` to avoid grep failures.
 
 ---
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -153,3 +153,12 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: avoid false positives when linting docs using a
   regex with `<{7}` style quantifiers.
 - **Next step**: none.
+
+## 2025-07-14  PR #13
+
+- **Summary**: updated AGENTS guide to v1.5 and clarified how to quote
+  conflict markers in docs.
+- **Stage**: documentation
+- **Motivation / Decision**: keep contributor rules clear so docs never
+  trigger the grep check.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -64,3 +64,4 @@
 - [ ] Automate updating the TODO header date whenever tasks change.
 - [x] Document local docs-only linting in AGENTS guide.
 - [x] Fix markdown formatting in NOTES template.
+- [ ] Note that conflict-marker quoting is documented in AGENTS guide.


### PR DESCRIPTION
## Summary
- document how to quote conflict markers
- bump AGENTS.md to v1.5
- log the change and add TODO reminder

## Testing
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_6874a3eab4c883258b8d093d1cb13893