### PR TITLE
Fix conflict marker doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.5 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.6 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -29,9 +29,8 @@ and run in local IDE to test manually.
   code-generated—never hand-edit; instead rerun the generator.
 - **Search for conflict markers before every commit** –
   `git grep -n -E '<{7}|={7}|>{7}'` must return nothing.
-- **Never include literal conflict markers in docs** –
-  use the `<{7}` notation (and similar) when referencing
-  `<<<<<<<`, `=======` or `>>>>>>>` to avoid grep failures.
+- **Never include conflict markers verbatim** –
+  mention them as `<{7}`, `={7}` or `>{7}` to keep grep quiet.
 
 ---
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -162,3 +162,12 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: keep contributor rules clear so docs never
   trigger the grep check.
 - **Next step**: none.
+
+## 2025-07-14  PR #14
+
+- **Summary**: updated AGENTS guide to v1.6 and explained using `<{7}` style
+  placeholders for conflict markers.
+- **Stage**: documentation
+- **Motivation / Decision**: avoid grep failures
+  when mentioning markers in docs.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -64,4 +64,4 @@
 - [ ] Automate updating the TODO header date whenever tasks change.
 - [x] Document local docs-only linting in AGENTS guide.
 - [x] Fix markdown formatting in NOTES template.
-- [ ] Note that conflict-marker quoting is documented in AGENTS guide.
+- [x] Note that conflict-marker quoting is documented in AGENTS guide.


### PR DESCRIPTION
## Summary
- clarify how to reference merge conflict markers in AGENTS guide
- bump guide version to v1.6
- log the change in NOTES
- tick TODO item about documenting conflict marker quoting

## Testing
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_6874a71aefe48325b5a38e663e5df062