### PR TITLE
Fix markdownlint and update guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.9 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.10 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -67,6 +67,7 @@ and run in local IDE to test manually.
   before committing.
    - When updating `NOTES.md` or `TODO.md` run `make lint-docs` to
      catch long-line issues locally.
+   - Always run `make lint-docs` after editing any Markdown file to avoid CI failures.
 3. **Style rules** – keep code formatted (`black`, `prettier`,
    `dart format`, etc.) and Markdown lines ≤ 80 chars;
    exactly **one blank line** separates log entries.

--- a/CODING_RULES.md
+++ b/CODING_RULES.md
@@ -1,4 +1,5 @@
 # Coding‑Guard
+
 1  One source file ⇢ one domain concept
 2  External imports ≤3 and never cyclic
 3  DRY: extract any ≥3‑line repetition into a helper

--- a/NOTES.md
+++ b/NOTES.md
@@ -220,11 +220,20 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 
 - **Summary**: updated AGENTS guide to v1.9 adding lint-docs reminder for NOTES/TODO.
 - **Stage**: documentation
-- **Motivation / Decision**: ensure log files stay within line length by prompting `make lint-docs`.
+- **Motivation / Decision**: ensure log files stay within line length
+  by prompting `make lint-docs`.
 
 ## 2025-07-14  PR #22
 
 - **Summary**: fixed long lines in NOTES so markdownlint passes.
 - **Stage**: maintenance
 - **Motivation / Decision**: keep history linter-compliant.
+- **Next step**: none.
+
+## 2025-07-14  PR #23
+
+- **Summary**: fixed markdownlint failures and updated AGENTS
+  to remind linting all docs.
+- **Stage**: maintenance
+- **Motivation / Decision**: keep CI green by enforcing doc linting.
 - **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -70,3 +70,4 @@
 - [x] Extend setup script to install dependencies automatically.
 
 - [x] Remind to run `make lint-docs` after editing NOTES or TODO.
+- [x] Emphasise linting all Markdown files in AGENTS guide.


### PR DESCRIPTION
## Summary
- fix blanks-around-headings in CODING_RULES
- break long lines in NOTES and add new entry
- document mandatory `make lint-docs` run after editing any Markdown
- tick TODO item

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6874b6581a4483259279ca4263b2c27b