### PR TITLE
Add TODO auto date script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.11 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.12 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -66,9 +66,11 @@ Follow the coding rules described in `CODING_RULES.md`.
 
    - For docs-only changes run `make lint` (or `make lint-docs`)
   before committing.
-   - When updating `NOTES.md` or `TODO.md` run `make lint-docs` to
-     catch long-line issues locally.
-   - Always run `make lint-docs` after editing any Markdown file to avoid CI failures.
+  - When updating `NOTES.md` or `TODO.md` run `make lint-docs` to
+    catch long-line issues locally.
+  - After editing `TODO.md` also run `make update-todo-date` to refresh
+    the header date.
+  - Always run `make lint-docs` after editing any Markdown file to avoid CI failures.
 3. **Style rules** – keep code formatted (`black`, `prettier`,
    `dart format`, etc.) and Markdown lines ≤ 80 chars;
    exactly **one blank line** separates log entries.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test generate
+.PHONY: lint test generate update-todo-date
 
 lint:
 	npx --yes markdownlint-cli **/*.md
@@ -12,3 +12,6 @@ test:
 
 generate:
 	python scripts/generate.py
+
+update-todo-date:
+	python scripts/update_todo_date.py

--- a/NOTES.md
+++ b/NOTES.md
@@ -244,3 +244,10 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Stage**: documentation
 - **Motivation / Decision**: follow newly added coding rules doc.
 - **Next step**: none.
+
+### 2025-07-14  PR #25
+
+- **Summary**: added script to update TODO header date with make target and tests.
+- **Stage**: implementation
+- **Motivation / Decision**: automate roadmap timestamp per roadmap item.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -61,7 +61,7 @@
  (append only; keep earlier history intact)
 
 - [x] Remove duplicate tagline from README
-- [ ] Automate updating the TODO header date whenever tasks change.
+- [x] Automate updating the TODO header date whenever tasks change.
 - [x] Document local docs-only linting in AGENTS guide.
 - [x] Fix markdown formatting in NOTES template.
 - [x] Note that conflict-marker quoting is documented in AGENTS guide.

--- a/scripts/update_todo_date.py
+++ b/scripts/update_todo_date.py
@@ -1,0 +1,41 @@
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+
+def update_todo_date(todo_path: Path) -> int:
+    """Update the date in the TODO header.
+
+    The first line must look like
+    '# TODO – Road‑map (last updated: YYYY-MM-DD)'.
+    """
+    try:
+        lines = todo_path.read_text().splitlines()
+    except Exception as exc:  # defensive coding
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    if not lines:
+        print("error: TODO file is empty", file=sys.stderr)
+        return 1
+
+    pattern = r"(# TODO – Road\u2011map \(last updated: )(\d{4}-\d{2}-\d{2})(\))"
+    match = re.match(pattern, lines[0])
+    if not match:
+        print("error: unexpected header format", file=sys.stderr)
+        return 1
+    today = date.today().isoformat()
+    if match.group(2) == today:
+        return 0
+    lines[0] = f"{match.group(1)}{today}{match.group(3)}"
+    try:
+        todo_path.write_text("\n".join(lines) + "\n")
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(__file__).resolve().parents[1] / "TODO.md"
+    sys.exit(update_todo_date(path))

--- a/tests/test_update_todo_date.py
+++ b/tests/test_update_todo_date.py
@@ -1,0 +1,23 @@
+import sys
+from datetime import date
+from pathlib import Path
+import subprocess
+
+
+def test_update_todo_date(tmp_path):
+    sample = (
+        "# TODO – Road‑map (last updated: 2000-01-01)\n"
+        "\n"
+        "rest\n"
+    )
+    todo_file = tmp_path / "TODO.md"
+    todo_file.write_text(sample)
+
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "scripts" / "update_todo_date.py"
+    result = subprocess.run([sys.executable, str(script), str(todo_file)])
+    assert result.returncode == 0
+
+    updated = todo_file.read_text().splitlines()[0]
+    today = date.today().isoformat()
+    assert updated == f"# TODO – Road‑map (last updated: {today})"


### PR DESCRIPTION
## Summary
- script to update TODO header date
- tests for update script
- make target `update-todo-date`
- guide mentions running the script
- tick roadmap item and log changes

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6874bc2879548325933ee123da45569f