### PR TITLE
docs: check pinned versions exist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.11 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.12 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -77,9 +77,12 @@ Follow the coding rules described in `CODING_RULES.md`.
    (e.g. fail fast when quality gates or metric thresholds aren’t met).
 5. **Version‑pin policy** – pin *major*/*minor* versions for critical runtimes &
    actions (e.g. `actions/checkout@v4`, `node@20`, `python~=3.11`).
-6. **When docs change, update them everywhere** – if ambiguity arises,
+6. **Confirm pinned packages exist** – verify each version listed in
+   `requirements.txt`, `package.json` or other manifests is available on
+   its package registry before committing.
+7. **When docs change, update them everywhere** – if ambiguity arises,
    `/docs` overrides this file.
-7. **Log discipline** – when a TODO item is ticked you **must** add the matching
+8. **Log discipline** – when a TODO item is ticked you **must** add the matching
    section in `NOTES.md` *in the same PR*; this keeps roadmap and log in‑sync.
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-.PHONY: lint test generate
+.PHONY: lint lint-docs test generate
 
 lint:
 	npx --yes markdownlint-cli **/*.md
+
+lint-docs: lint
 
 test:
 	@if [ -d tests ]; then \

--- a/NOTES.md
+++ b/NOTES.md
@@ -244,3 +244,10 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Stage**: documentation
 - **Motivation / Decision**: follow newly added coding rules doc.
 - **Next step**: none.
+
+## 2025-07-14  PR #25
+
+- **Summary**: AGENTS v1.12 instructs verifying pinned package versions exist.
+- **Stage**: documentation
+- **Motivation / Decision**: ensure pinned dependencies point to real versions.
+- **Next step**: add tooling to automate the check.

--- a/TODO.md
+++ b/TODO.md
@@ -72,3 +72,4 @@
 - [x] Remind to run `make lint-docs` after editing NOTES or TODO.
 - [x] Emphasise linting all Markdown files in AGENTS guide.
 - [x] Mention CODING_RULES doc link in AGENTS guide.
+- [ ] Provide script to check pinned package versions exist.


### PR DESCRIPTION
## Summary
- remind contributors to ensure pinned versions exist
- add alias `lint-docs` to Makefile
- record the change in NOTES and roadmap

## Testing
- `make lint-docs`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6874bc2ba2d08325a84fcb5d2f285ff2