### PR TITLE
Fix doc lint issues and bullet style

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.12 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.13 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -64,13 +64,13 @@ Follow the coding rules described in `CODING_RULES.md`.
    make test                  # project’s unit‑/integration tests
    ```
 
-   - For docs-only changes run `make lint` (or `make lint-docs`)
-  before committing.
-  - When updating `NOTES.md` or `TODO.md` run `make lint-docs` to
-    catch long-line issues locally.
-  - After editing `TODO.md` also run `make update-todo-date` to refresh
-    the header date.
-  - Always run `make lint-docs` after editing any Markdown file to avoid CI failures.
+    - For docs-only changes run `make lint` (or `make lint-docs`) before committing.
+    - When updating `NOTES.md` or `TODO.md` run `make lint-docs` to
+      catch long-line issues locally.
+    - After editing `TODO.md` also run `make update-todo-date` to refresh
+      the header date.
+    - Always run `make lint-docs` after editing any Markdown file to avoid CI failures.
+
 3. **Style rules** – keep code formatted (`black`, `prettier`,
    `dart format`, etc.) and Markdown lines ≤ 80 chars;
    exactly **one blank line** separates log entries.
@@ -164,6 +164,7 @@ jobs:
 - Keep Markdown lines ≤ 80 chars to improve diff readability
    (tables may exceed if unavoidable).
 - Use `-` for bullet lists.
+- Indent nested bullet lists by two spaces relative to their parent item.
 - Use a normal space after `#` in headings.
 - Avoid inline HTML.
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -247,9 +247,11 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 
 ### 2025-07-14 mediapipe downgrade
 
-- **Summary**: downgraded mediapipe to 0.10.13 so numpy 2 works; added dependency note in README.
+- **Summary**: downgraded mediapipe to 0.10.13 so numpy 2 works;
+   added dependency note in README.
 - **Stage**: maintenance
-- **Motivation / Decision**: mediapipe 0.10.21 required numpy<2; earliest PyPI wheel supporting numpy 2 is 0.10.13.
+- **Motivation / Decision**: mediapipe 0.10.21 required numpy<2;
+  earliest PyPI wheel supporting numpy 2 is 0.10.13.
 - **Next step**: monitor mediapipe releases for numpy 2 default.
 
 ## 2025-07-14  PR #25
@@ -270,4 +272,11 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Summary**: updated TypeScript dev dependency to 5.5.4.
 - **Stage**: maintenance
 - **Motivation / Decision**: keep tooling current for bug fixes.
+- **Next step**: none.
+
+## 2025-07-15  PR #28
+
+- **Summary**: fixed bullet indentation, README spacing and bumped AGENTS to v1.13.
+- **Stage**: documentation
+- **Motivation / Decision**: keep markdownlint green and clarify nested list style.
 - **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ cd PoseDetection
 make lint
 make test
 ```
+
 The Python dependencies install `mediapipe==0.10.13` which supports
 `numpy>=2`.
 

--- a/TODO.md
+++ b/TODO.md
@@ -75,3 +75,5 @@
 - [ ] Regularly verify dependency versions for compatibility issues.
 - [ ] Provide script to check pinned package versions exist.
 - [x] Update TypeScript to 5.5.4 in package.json.
+
+- [x] Clarify nested bullet indentation rule in AGENTS guide.


### PR DESCRIPTION
## Summary
- reindent the pre-commit bullet list in AGENTS.md
- clarify nested bullet rule and bump AGENTS version to v1.13
- add a blank line after the quick-start block in README
- tidy mediapipe downgrade note and log doc fixes in NOTES
- tick TODO for bullet indentation rule

## Testing
- `make lint-docs`

------
https://chatgpt.com/codex/tasks/task_e_6874bfdbfe4c8325a0792d34178d60dc