### PR TITLE
Document script public functions

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -280,3 +280,9 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Stage**: documentation
 - **Motivation / Decision**: keep markdownlint green and clarify nested list style.
 - **Next step**: none.
+
+## 2025-07-14  PR #29
+- **Summary**: documented script public functions with params, returns and raises.
+- **Stage**: documentation
+- **Motivation / Decision**: follow CODING_RULES rule 18 to improve clarity.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -77,3 +77,4 @@
 - [x] Update TypeScript to 5.5.4 in package.json.
 
 - [x] Clarify nested bullet indentation rule in AGENTS guide.
+- [x] Document public functions in scripts for clarity.

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -3,7 +3,26 @@ from pathlib import Path
 
 
 def generate() -> int:
-    """Write placeholder output under generated/example.txt."""
+    """Create the example file used in tests.
+
+    Purpose
+    -------
+    Write ``placeholder output`` to ``generated/example.txt`` so unit
+    tests have a known artefact to check.
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    int
+        ``0`` on success, ``1`` when a filesystem error occurs.
+
+    Raises
+    ------
+    None: all exceptions are caught and converted into the return code.
+    """
     try:
         out_path = Path(__file__).resolve().parents[1] / "generated" / "example.txt"
         out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/update_todo_date.py
+++ b/scripts/update_todo_date.py
@@ -5,10 +5,28 @@ from pathlib import Path
 
 
 def update_todo_date(todo_path: Path) -> int:
-    """Update the date in the TODO header.
+    """Refresh the date in the TODO header.
 
-    The first line must look like
-    '# TODO – Road‑map (last updated: YYYY-MM-DD)'.
+    Purpose
+    -------
+    Ensure the first line of ``TODO.md`` reflects today's date. The expected
+    format is ``# TODO – Road‑map (last updated: YYYY-MM-DD)``.
+
+    Parameters
+    ----------
+    todo_path : Path
+        Location of the TODO file to update.
+
+    Returns
+    -------
+    int
+        ``0`` when the date is current or was updated, ``1`` on errors.
+
+    Raises
+    ------
+    ValueError
+        If the header line does not match the expected pattern. File related
+        issues are caught and converted into the return code.
     """
     try:
         lines = todo_path.read_text().splitlines()


### PR DESCRIPTION
## Summary
- expand docstrings in `scripts/generate.py` and `scripts/update_todo_date.py`
- log the change in NOTES
- tick roadmap for script documentation

## Testing
- `make lint-docs`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6874c75c5aa883258ef2ba7735a0d13a