### PR TITLE
Add package version checker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ Follow the coding rules described in `CODING_RULES.md`.
     - After editing `TODO.md` also run `make update-todo-date` to refresh
       the header date.
     - Always run `make lint-docs` after editing any Markdown file to avoid CI failures.
+    - Run `make check-versions` when changing dependencies to verify pinned versions exist.
 
 3. **Style rules** – keep code formatted (`black`, `prettier`,
    `dart format`, etc.) and Markdown lines ≤ 80 chars;

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,6 @@ generate:
 
 update-todo-date:
 	python scripts/update_todo_date.py
+
+check-versions:
+	python scripts/check_versions.py

--- a/NOTES.md
+++ b/NOTES.md
@@ -280,3 +280,11 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Stage**: documentation
 - **Motivation / Decision**: keep markdownlint green and clarify nested list style.
 - **Next step**: none.
+
+## 2025-07-14  PR #29
+
+- **Summary**: added script to verify pinned dependency versions with make target.
+- **Stage**: implementation
+- **Motivation / Decision**: automate version checks to enforce pin policy.
+- **Next step**: watch for version conflicts in future updates.
+

--- a/TODO.md
+++ b/TODO.md
@@ -73,7 +73,7 @@
 - [x] Emphasise linting all Markdown files in AGENTS guide.
 - [x] Mention CODING_RULES doc link in AGENTS guide.
 - [ ] Regularly verify dependency versions for compatibility issues.
-- [ ] Provide script to check pinned package versions exist.
+- [x] Provide script to check pinned package versions exist.
 - [x] Update TypeScript to 5.5.4 in package.json.
 
 - [x] Clarify nested bullet indentation rule in AGENTS guide.

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -1,0 +1,90 @@
+import json
+import sys
+from pathlib import Path
+from urllib import request, error
+
+
+PYPI_URL = "https://pypi.org/pypi/{name}/{version}/json"
+NPM_URL = "https://registry.npmjs.org/{name}/{version}"
+
+
+def parse_requirements(req_path: Path) -> dict[str, str]:
+    """Return package versions from requirements.txt."""
+    packages: dict[str, str] = {}
+    for line in req_path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "==" not in line:
+            continue
+        name, version = line.split("==", 1)
+        name = name.split("[", 1)[0]
+        packages[name] = version
+    return packages
+
+
+def parse_package_json(json_path: Path) -> dict[str, str]:
+    """Return dependencies from package.json."""
+    data = json.loads(json_path.read_text())
+    packages: dict[str, str] = {}
+    for section in ("dependencies", "devDependencies"):
+        for name, version in data.get(section, {}).items():
+            packages[name] = version
+    return packages
+
+
+def parse_package_lock(lock_path: Path) -> dict[str, str]:
+    """Return dependencies from package-lock.json."""
+    data = json.loads(lock_path.read_text())
+    root = data.get("packages", {}).get("", {})
+    packages: dict[str, str] = {}
+    for section in ("dependencies", "devDependencies"):
+        for name, version in root.get(section, {}).items():
+            packages[name] = version
+    return packages
+
+
+def version_exists(url: str) -> bool:
+    try:
+        with request.urlopen(url):
+            return True
+    except error.HTTPError as exc:
+        if exc.code == 404:
+            return False
+        print(f"error: {exc}", file=sys.stderr)
+    except Exception as exc:  # defensive coding
+        print(f"error: {exc}", file=sys.stderr)
+    return False
+
+
+def check_versions(repo_dir: Path) -> int:
+    """Check all pinned versions in the repository."""
+    failed = False
+    req_file = repo_dir / "requirements.txt"
+    if req_file.exists():
+        for name, version in parse_requirements(req_file).items():
+            url = PYPI_URL.format(name=name, version=version)
+            if not version_exists(url):
+                print(f"{name}=={version} not found on PyPI", file=sys.stderr)
+                failed = True
+    lock_file = repo_dir / "package-lock.json"
+    pkg_file = repo_dir / "package.json"
+    if lock_file.exists():
+        deps = parse_package_lock(lock_file)
+    elif pkg_file.exists():
+        deps = parse_package_json(pkg_file)
+    else:
+        deps = {}
+    for name, version in deps.items():
+        if not version or version[0] in "^~":
+            continue
+        url = NPM_URL.format(name=name, version=version)
+        if not version_exists(url):
+            print(f"{name}@{version} not found on npm", file=sys.stderr)
+            failed = True
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(__file__).resolve().parents[1]
+    sys.exit(check_versions(root))

--- a/tests/test_check_versions.py
+++ b/tests/test_check_versions.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+import scripts.check_versions as cv
+
+
+def fake_urlopen_success(url):
+    class Resp:
+        status = 200
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+    return Resp()
+
+
+def fake_urlopen_fail(url):
+    raise cv.error.HTTPError(url, 404, "not found", hdrs=None, fp=None)
+
+
+def test_check_versions_cli_success(tmp_path, monkeypatch):
+    (tmp_path / "requirements.txt").write_text("pkg==1.0.0\n")
+    (tmp_path / "package.json").write_text(json.dumps({"dependencies": {"a": "1.0.0"}}))
+    monkeypatch.setattr(cv.request, "urlopen", fake_urlopen_success)
+    assert cv.check_versions(tmp_path) == 0
+
+
+def test_check_versions_cli_fail(tmp_path, monkeypatch):
+    (tmp_path / "requirements.txt").write_text("pkg==1.0.0\n")
+    (tmp_path / "package.json").write_text(json.dumps({"dependencies": {"a": "1.0.0"}}))
+    monkeypatch.setattr(cv.request, "urlopen", fake_urlopen_fail)
+    assert cv.check_versions(tmp_path) == 1


### PR DESCRIPTION
## Summary
- automate verifying pinned versions via `scripts/check_versions.py`
- add `make check-versions` target
- document the new target in the contributor guide
- tick roadmap item about the version check script
- log the change in NOTES
- test checking versions

## Testing
- `make lint-docs`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6874c7740ae083259cc2cd7618f5f9a5