### PR TITLE
Update style rules and fix lint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.14 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.15 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -75,6 +75,7 @@ Follow the coding rules described in `CODING_RULES.md`.
 
 3. **Style rules** – keep code formatted (`black`, `prettier`,
    `dart format`, etc.) and Markdown lines ≤ 80 chars;
+   avoid multiple consecutive blank lines (markdownlint MD012);
    exactly **one blank line** separates log entries.
 4. **Exit‑code conventions** – scripts must exit ≠ 0 on failure so
    CI catches regressions

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 lint:
 	npx --yes markdownlint-cli **/*.md
-	ruff scripts tests
+	ruff check scripts tests
 
 lint-docs: lint
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -312,3 +312,10 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Stage**: documentation
 - **Motivation / Decision**: follow CODING_RULES rule 18 to improve clarity.
 - **Next step**: none.
+
+### 2025-07-16  PR #34
+
+- **Summary**: added markdown blank line rule to AGENTS and fixed Makefile lint command.
+- **Stage**: documentation
+- **Motivation / Decision**: keep contributor guide accurate and ensure ruff works with current version.
+- **Next step**: none.

--- a/tests/test_check_versions.py
+++ b/tests/test_check_versions.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 import scripts.check_versions as cv
 


### PR DESCRIPTION
## Summary
- clarify style rules with markdownlint MD012
- bump AGENTS guide version
- fix `lint` target for newer ruff
- remove unused import flagged by ruff

## Testing
- `make lint-docs`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6874cb3d96b48325be3f3201ac769f17