### PR TITLE
Pin websockets dependency

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -328,3 +328,10 @@ and fixed Makefile lint command.
 - **Motivation / Decision**: keep contributor guide accurate
 and ensure ruff works with current version.
 - **Next step**: none.
+
+### 2025-07-17  PR #36
+
+- **Summary**: pinned websockets and updated README and TODO.
+- **Stage**: maintenance
+- **Motivation / Decision**: prepare for upcoming WebSocket features.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ make lint
 make test
 ```
 
-The Python dependencies install `mediapipe==0.10.13` which supports
-`numpy>=2`.
+The Python dependencies install `mediapipe==0.10.13` and
+`websockets==15.0.1`. Mediapipe 0.10.13 supports `numpy>=2`.
 
 ## Development
 

--- a/TODO.md
+++ b/TODO.md
@@ -78,3 +78,4 @@
 - [x] Add Python linter (`ruff`) and update docs to mention new lint step.
 - [x] Add MIT license file and reference it in README.
 - [x] Document public functions in scripts for clarity.
+- [ ] Pin `websockets` dependency and update README accordingly.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]==0.35.0
 opencv-python==4.12.0.88
 mediapipe==0.10.13
 ruff==0.4.4
+websockets==15.0.1


### PR DESCRIPTION
## Summary
- pin websockets in `requirements.txt`
- verify version using `make check-versions`
- document websockets dependency in README
- log the change in NOTES and add a TODO item

## Testing
- `make check-versions`
- `make lint`
- `make test`
- `make lint-docs`


------
https://chatgpt.com/codex/tasks/task_e_6874cfb6c7108325bf1af85ccf9c9fb5