### PR TITLE
Add analytics module with WebSocket integration

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -343,3 +343,12 @@ and ensure ruff works with current version.
 - **Stage**: maintenance
 - **Motivation / Decision**: keep roadmap accurate with repository state.
 - **Next step**: none.
+
+### 2025-07-18  PR #38
+
+- **Summary**: added analytics module for angle and balance, WebSocket server and
+  docs.
+- **Stage**: implementation
+- **Motivation / Decision**: integrate backend metrics to follow tech
+  challenge.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -79,3 +79,4 @@
 - [x] Add MIT license file and reference it in README.
 - [x] Document public functions in scripts for clarity.
 - [x] Pin `websockets` dependency and update README accordingly.
+- [ ] Add backend analytics module with WebSocket integration.

--- a/backend/analytics.py
+++ b/backend/analytics.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from math import atan2, degrees, sqrt
+from typing import Dict, Mapping
+
+
+Point = Mapping[str, float]
+
+
+def _validate_point(pt: Point) -> None:
+    if pt is None or 'x' not in pt or 'y' not in pt:
+        raise ValueError('invalid point')
+
+
+def calculate_angle(a: Point, b: Point, c: Point) -> float:
+    """Return the angle ABC in degrees.
+
+    Parameters
+    ----------
+    a, b, c : Mapping[str, float]
+        Points with ``x`` and ``y`` coordinates.
+
+    Returns
+    -------
+    float
+        Angle at point ``b`` in degrees.
+
+    Raises
+    ------
+    ValueError
+        If any point is missing coordinates.
+    """
+    _validate_point(a)
+    _validate_point(b)
+    _validate_point(c)
+    abx = a['x'] - b['x']
+    aby = a['y'] - b['y']
+    cbx = c['x'] - b['x']
+    cby = c['y'] - b['y']
+    dot = abx * cbx + aby * cby
+    mag_ab = sqrt(abx ** 2 + aby ** 2)
+    mag_cb = sqrt(cbx ** 2 + cby ** 2)
+    if mag_ab == 0 or mag_cb == 0:
+        raise ValueError('zero-length vector')
+    cos_angle = max(min(dot / (mag_ab * mag_cb), 1.0), -1.0)
+    return degrees(atan2(sqrt(1 - cos_angle ** 2), cos_angle))
+
+
+def balance_score(landmarks: Mapping[str, Point]) -> float:
+    """Return a simple left/right balance score.
+
+    Parameters
+    ----------
+    landmarks : Mapping[str, Point]
+        Pose landmarks keyed by name. Requires ``left_hip`` and ``right_hip``.
+
+    Returns
+    -------
+    float
+        Absolute x-axis difference between hips (0..1 range).
+
+    Raises
+    ------
+    ValueError
+        If required landmarks are missing.
+    """
+    left = landmarks.get('left_hip')
+    right = landmarks.get('right_hip')
+    _validate_point(left)
+    _validate_point(right)
+    return abs(left['x'] - right['x'])
+
+
+def extract_pose_metrics(landmarks: Mapping[str, Point]) -> Dict[str, float]:
+    """Return analytics dictionary from pose landmarks."""
+    try:
+        knee_angle = calculate_angle(
+            landmarks['hip'], landmarks['knee'], landmarks['ankle']
+        )
+    except KeyError:
+        knee_angle = float('nan')
+    except ValueError:
+        knee_angle = float('nan')
+    try:
+        balance = balance_score(landmarks)
+    except ValueError:
+        balance = float('nan')
+    return {'knee_angle': knee_angle, 'balance': balance}

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+import cv2
+import mediapipe as mp
+from fastapi import FastAPI, WebSocket
+
+from .analytics import extract_pose_metrics
+
+app = FastAPI()
+mp_pose = mp.solutions.pose.Pose()
+
+
+@app.websocket("/pose")
+async def pose_endpoint(ws: WebSocket) -> None:
+    """Stream pose metrics over WebSocket."""
+    await ws.accept()
+    cap = cv2.VideoCapture(0)
+    try:
+        while True:
+            ok, frame = cap.read()
+            if not ok:
+                await ws.send_text(json.dumps({"error": "no frame"}))
+                break
+
+            rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            results = mp_pose.process(rgb)
+            if not results.pose_landmarks:
+                await ws.send_text(json.dumps({"error": "no landmarks"}))
+                continue
+
+            lms: dict[str, dict[str, float]] = {}
+            for idx, landmark in enumerate(results.pose_landmarks.landmark):
+                name = mp.solutions.pose.PoseLandmark(idx).name.lower()
+                lms[name] = {"x": landmark.x, "y": landmark.y}
+
+            metrics = extract_pose_metrics(lms)
+            await ws.send_text(json.dumps(metrics))
+    finally:
+        cap.release()

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,22 @@ full assignment and requirements are listed in
 [tech-challenge.txt](tech-challenge.txt).
 
 Placeholder for project docs.
+
+## Backend analytics
+
+The backend exposes a WebSocket endpoint at `/pose`. It captures webcam frames
+with MediaPipe and streams pose metrics as JSON. The metrics are calculated in
+`backend/analytics.py`:
+
+```python
+from backend.analytics import extract_pose_metrics
+
+# landmarks is a dict like {'hip': {'x': 0.5, 'y': 0.5}, ...}
+metrics = extract_pose_metrics(landmarks)
+```
+
+Run the server with:
+
+```bash
+python -m backend.server
+```

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,29 @@
+import math
+import pytest
+
+from backend.analytics import calculate_angle, balance_score, extract_pose_metrics
+
+
+def test_calculate_angle_basic():
+    a = {'x': 0.0, 'y': 0.0}
+    b = {'x': 1.0, 'y': 0.0}
+    c = {'x': 1.0, 'y': 1.0}
+    angle = calculate_angle(a, b, c)
+    assert math.isclose(angle, 90.0, abs_tol=1e-2)
+
+
+def test_calculate_angle_invalid():
+    a = {'x': 0.0}
+    with pytest.raises(ValueError):
+        calculate_angle(a, {'x': 0.0, 'y': 0.0}, {'x': 1.0, 'y': 0.0})
+
+
+def test_balance_score_missing():
+    with pytest.raises(ValueError):
+        balance_score({})
+
+
+def test_extract_pose_metrics_missing_landmarks():
+    metrics = extract_pose_metrics({})
+    assert math.isnan(metrics['knee_angle'])
+    assert math.isnan(metrics['balance'])


### PR DESCRIPTION
## Summary
- implement backend analytics for angle and balance calculations
- create WebSocket endpoint streaming these metrics
- test analytics functions for edge cases
- document backend usage in docs/README
- log progress in NOTES and update TODO

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6874d39f8c4483258a09424288ec8ed2