### PR TITLE
Implement pose detection backend

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -343,3 +343,9 @@ and ensure ruff works with current version.
 - **Stage**: maintenance
 - **Motivation / Decision**: keep roadmap accurate with repository state.
 - **Next step**: none.
+
+### 2025-07-14  PR #38
+- **Summary**: implemented MediaPipe pose detector and FastAPI WebSocket server.
+- **Stage**: implementation
+- **Motivation / Decision**: needed backend to stream 17 keypoints per frame.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ make test
 The Python dependencies install `mediapipe==0.10.13` and
 `websockets==15.0.1`. Mediapipe 0.10.13 supports `numpy>=2`.
 
+### Backend server
+
+Run `python -m backend.main` to launch the FastAPI server. The `/pose`
+WebSocket streams pose keypoints extracted from each video frame.
+
 ## Development
 
 Run `make lint` to check Markdown and Python code style (ruff).

--- a/TODO.md
+++ b/TODO.md
@@ -79,3 +79,4 @@
 - [x] Add MIT license file and reference it in README.
 - [x] Document public functions in scripts for clarity.
 - [x] Pin `websockets` dependency and update README accordingly.
+- [x] Add MediaPipe pose detector and FastAPI server with `/pose` WebSocket.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,30 @@
+from fastapi import FastAPI, WebSocket
+import cv2
+
+from .pose_detector import PoseDetector
+
+app = FastAPI()
+_detector = PoseDetector()
+_capture = cv2.VideoCapture(0)
+
+
+@app.on_event("shutdown")
+def _cleanup() -> None:
+    _capture.release()
+
+
+@app.websocket("/pose")
+async def pose_stream(websocket: WebSocket) -> None:
+    """Send pose keypoints for each captured frame."""
+    await websocket.accept()
+    try:
+        while True:
+            ret, frame = _capture.read()
+            if not ret:
+                await websocket.send_json({"error": "capture failed"})
+                break
+            keypoints = _detector.process(frame)
+            await websocket.send_json({"keypoints": keypoints})
+    except Exception:
+        await websocket.close()
+        raise

--- a/backend/pose_detector.py
+++ b/backend/pose_detector.py
@@ -1,0 +1,27 @@
+import cv2
+import mediapipe as mp
+import numpy as np
+
+
+class PoseDetector:
+    """Extract 17 pose keypoints from a BGR video frame."""
+
+    def __init__(self) -> None:
+        self._pose = mp.solutions.pose.Pose(model_complexity=1)
+
+    def process(self, frame: np.ndarray) -> list[dict[str, float]]:
+        """Return 17 keypoints as dicts with x, y and visibility."""
+        if frame is None:
+            raise ValueError('frame is None')
+        rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        results = self._pose.process(rgb)
+        if not results.pose_landmarks:
+            return []
+        keypoints = []
+        for lm in results.pose_landmarks.landmark[:17]:
+            keypoints.append({
+                'x': float(lm.x),
+                'y': float(lm.y),
+                'visibility': float(lm.visibility),
+            })
+        return keypoints

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ opencv-python==4.12.0.88
 mediapipe==0.10.13
 ruff==0.4.4
 websockets==15.0.1
+httpx==0.27.0

--- a/tests/backend/test_main.py
+++ b/tests/backend/test_main.py
@@ -1,0 +1,36 @@
+import numpy as np
+from fastapi.testclient import TestClient
+import backend.main as main
+
+
+class FakeCapture:
+    def __init__(self, ret=True):
+        self._ret = ret
+        self.frame = np.zeros((1, 1, 3), dtype=np.uint8)
+
+    def read(self):
+        return self._ret, self.frame
+
+
+class FakeDetector:
+    def process(self, frame):
+        return [{"x": 0.0, "y": 0.0, "visibility": 1.0}]
+
+
+def test_pose_stream_success(monkeypatch):
+    monkeypatch.setattr(main, "_capture", FakeCapture())
+    monkeypatch.setattr(main, "_detector", FakeDetector())
+    client = TestClient(main.app)
+    with client.websocket_connect("/pose") as ws:
+        data = ws.receive_json()
+        assert "keypoints" in data
+        assert data["keypoints"][0]["visibility"] == 1.0
+
+
+def test_pose_stream_capture_fail(monkeypatch):
+    monkeypatch.setattr(main, "_capture", FakeCapture(ret=False))
+    monkeypatch.setattr(main, "_detector", FakeDetector())
+    client = TestClient(main.app)
+    with client.websocket_connect("/pose") as ws:
+        data = ws.receive_json()
+        assert data == {"error": "capture failed"}

--- a/tests/backend/test_pose_detector.py
+++ b/tests/backend/test_pose_detector.py
@@ -1,0 +1,32 @@
+import types
+import numpy as np
+import backend.pose_detector as pd
+import mediapipe as mp
+
+
+class FakePose:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def process(self, frame):
+        lm = types.SimpleNamespace(x=1.0, y=2.0, visibility=0.5)
+        return types.SimpleNamespace(pose_landmarks=types.SimpleNamespace(landmark=[lm] * 33))
+
+
+def test_process_success(monkeypatch):
+    monkeypatch.setattr(mp.solutions.pose, "Pose", FakePose)
+    det = pd.PoseDetector()
+    frame = np.zeros((1, 1, 3), dtype=np.uint8)
+    result = det.process(frame)
+    assert len(result) == 17
+    assert result[0]["x"] == 1.0
+
+
+def test_process_none():
+    det = pd.PoseDetector()
+    try:
+        det.process(None)
+    except ValueError:
+        pass
+    else:
+        assert False


### PR DESCRIPTION
## Summary
- add MediaPipe pose detector and FastAPI websocket server
- document backend usage
- test pose detector and websocket endpoint
- pin `httpx` for test client
- log progress in NOTES

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6874d39d87d0832595adbac639e722a5