### PR TITLE
Support side-specific pose metrics

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -359,3 +359,10 @@ and ensure ruff works with current version.
 - **Motivation / Decision**: integrate backend metrics to follow tech
   challenge.
 - **Next step**: none.
+
+### 2025-07-18  PR #40
+
+- **Summary**: updated pose metrics extraction to use side-specific landmarks and added tests.
+- **Stage**: implementation
+- **Motivation / Decision**: ensure analytics support left/right joint names and behave correctly when landmarks are provided or missing.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -81,3 +81,4 @@
 - [x] Pin `websockets` dependency and update README accordingly.
 - [ ] Basic React frontend with PoseViewer and WebSocket hook.
 - [ ] Add backend analytics module with WebSocket integration.
+- [x] Support side-specific landmarks in `extract_pose_metrics`.

--- a/backend/analytics.py
+++ b/backend/analytics.py
@@ -73,14 +73,20 @@ def balance_score(landmarks: Mapping[str, Point]) -> float:
 
 def extract_pose_metrics(landmarks: Mapping[str, Point]) -> Dict[str, float]:
     """Return analytics dictionary from pose landmarks."""
-    try:
-        knee_angle = calculate_angle(
-            landmarks['hip'], landmarks['knee'], landmarks['ankle']
-        )
-    except KeyError:
-        knee_angle = float('nan')
-    except ValueError:
-        knee_angle = float('nan')
+    knee_angle = float("nan")
+    for side in ("left", "right"):
+        try:
+            knee_angle = calculate_angle(
+                landmarks[f"{side}_hip"],
+                landmarks[f"{side}_knee"],
+                landmarks[f"{side}_ankle"],
+            )
+            break
+        except KeyError:
+            continue
+        except ValueError:
+            knee_angle = float("nan")
+            break
     try:
         balance = balance_score(landmarks)
     except ValueError:

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ with MediaPipe and streams pose metrics as JSON. The metrics are calculated in
 ```python
 from backend.analytics import extract_pose_metrics
 
-# landmarks is a dict like {'hip': {'x': 0.5, 'y': 0.5}, ...}
+# landmarks is a dict like {'left_hip': {'x': 0.5, 'y': 0.5}, ...}
 metrics = extract_pose_metrics(landmarks)
 ```
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -27,3 +27,27 @@ def test_extract_pose_metrics_missing_landmarks():
     metrics = extract_pose_metrics({})
     assert math.isnan(metrics['knee_angle'])
     assert math.isnan(metrics['balance'])
+
+
+def test_extract_pose_metrics_left_side():
+    lms = {
+        'left_hip': {'x': 0.0, 'y': 0.0},
+        'left_knee': {'x': 0.0, 'y': 1.0},
+        'left_ankle': {'x': 1.0, 'y': 1.0},
+        'right_hip': {'x': 1.0, 'y': 0.0},
+    }
+    metrics = extract_pose_metrics(lms)
+    assert not math.isnan(metrics['knee_angle'])
+    assert not math.isnan(metrics['balance'])
+
+
+def test_extract_pose_metrics_right_side():
+    lms = {
+        'right_hip': {'x': 1.0, 'y': 0.0},
+        'right_knee': {'x': 1.0, 'y': 1.0},
+        'right_ankle': {'x': 0.0, 'y': 1.0},
+        'left_hip': {'x': 0.0, 'y': 0.0},
+    }
+    metrics = extract_pose_metrics(lms)
+    assert not math.isnan(metrics['knee_angle'])
+    assert not math.isnan(metrics['balance'])


### PR DESCRIPTION
## Summary
- compute `knee_angle` using left or right landmarks
- test analytics on left and right sides
- show side-specific landmarks in docs
- note the change in development log

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6874d92e49d883258613bace6910e796