### PR TITLE
Add webcam stream hook with test

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -359,3 +359,10 @@ and ensure ruff works with current version.
 - **Motivation / Decision**: integrate backend metrics to follow tech
   challenge.
 - **Next step**: none.
+
+### 2025-07-14  PR #40
+
+- **Summary**: PoseViewer now requests webcam with cleanup and tests mock the stream.
+- **Stage**: implementation
+- **Motivation / Decision**: completed TODO webcam feature using custom mock as jest-mock-media was unavailable.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -79,5 +79,5 @@
 - [x] Add MIT license file and reference it in README.
 - [x] Document public functions in scripts for clarity.
 - [x] Pin `websockets` dependency and update README accordingly.
-- [ ] Basic React frontend with PoseViewer and WebSocket hook.
-- [ ] Add backend analytics module with WebSocket integration.
+- [x] Basic React frontend with PoseViewer and WebSocket hook.
+- [x] Add backend analytics module with WebSocket integration.

--- a/frontend/src/__tests__/PoseViewer.test.tsx
+++ b/frontend/src/__tests__/PoseViewer.test.tsx
@@ -1,0 +1,29 @@
+import { render, waitFor } from '@testing-library/react';
+import PoseViewer from '../components/PoseViewer';
+import '@testing-library/jest-dom';
+
+class FakeStream {
+  getTracks() {
+    return [];
+  }
+}
+
+function mockMedia() {
+  const stream = new FakeStream() as unknown as MediaStream;
+  const getUserMedia = jest.fn().mockResolvedValue(stream);
+  Object.defineProperty(navigator, 'mediaDevices', {
+    value: { getUserMedia },
+    configurable: true,
+  });
+  return { stream, getUserMedia };
+}
+
+test('assigns webcam stream to video element', async () => {
+  const { stream, getUserMedia } = mockMedia();
+  const { container } = render(<PoseViewer />);
+  await waitFor(() => {
+    const video = container.querySelector('video') as HTMLVideoElement;
+    expect(video.srcObject).toBe(stream);
+  });
+  expect(getUserMedia).toHaveBeenCalled();
+});

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -14,6 +14,29 @@ const PoseViewer: React.FC = () => {
   const { poseData } = useWebSocket<PoseData>('/pose');
 
   useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    let active = true;
+    navigator.mediaDevices
+      .getUserMedia({ video: true })
+      .then((stream) => {
+        if (active) {
+          video.srcObject = stream;
+        }
+      })
+      .catch(() => {
+        // ignore failure to access webcam
+      });
+    return () => {
+      active = false;
+      const src = video.srcObject as MediaStream | null;
+      if (src) {
+        for (const t of src.getTracks()) t.stop();
+      }
+    };
+  }, []);
+
+  useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas || !poseData) return;
     const ctx = canvas.getContext('2d');


### PR DESCRIPTION
## Summary
- request webcam stream in PoseViewer via `navigator.mediaDevices.getUserMedia`
- assign the stream to the video element and stop tracks on cleanup
- add Jest test mocking `getUserMedia`
- tick TODO items for frontend and analytics
- log changes in NOTES

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6874d92f9cfc832585a31c1ce300167b