### PR TITLE
Add uvicorn entrypoint and docs

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -359,3 +359,10 @@ and ensure ruff works with current version.
 - **Motivation / Decision**: integrate backend metrics to follow tech
   challenge.
 - **Next step**: none.
+
+### 2025-07-19  PR #40
+
+- **Summary**: added uvicorn entrypoint for backend server, updated docs and tests.
+- **Stage**: implementation
+- **Motivation / Decision**: allow running `python -m backend.server` and verify startup.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ npm run build
 npm test
 ```
 
+## Backend
+
+Start the API server with:
+
+```bash
+python -m backend.server
+```
+
 ## License
 
 PoseDetection is released under the MIT License. See [LICENSE](LICENSE).

--- a/TODO.md
+++ b/TODO.md
@@ -81,3 +81,4 @@
 - [x] Pin `websockets` dependency and update README accordingly.
 - [ ] Basic React frontend with PoseViewer and WebSocket hook.
 - [ ] Add backend analytics module with WebSocket integration.
+- [x] Add server entrypoint and startup test for backend.

--- a/backend/server.py
+++ b/backend/server.py
@@ -7,6 +7,8 @@ from fastapi import FastAPI, WebSocket
 
 from .analytics import extract_pose_metrics
 
+import uvicorn
+
 app = FastAPI()
 mp_pose = mp.solutions.pose.Pose()
 
@@ -38,3 +40,12 @@ async def pose_endpoint(ws: WebSocket) -> None:
             await ws.send_text(json.dumps(metrics))
     finally:
         cap.release()
+
+
+def main() -> None:
+    """Launch the FastAPI application using uvicorn."""
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ from backend.analytics import extract_pose_metrics
 metrics = extract_pose_metrics(landmarks)
 ```
 
-Run the server with:
+Start the backend server with:
 
 ```bash
 python -m backend.server

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,19 @@
+import sys
+import subprocess
+import time
+
+
+def test_server_starts():
+    proc = subprocess.Popen(
+        [sys.executable, '-m', 'backend.server'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    try:
+        time.sleep(1)
+        assert proc.poll() is None
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)
+
+


### PR DESCRIPTION
## Summary
- run uvicorn when `backend.server` is executed as a module
- document the new command in both READMEs
- add a unit test that spawns the server with subprocess
- log the change in NOTES and TODO

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6874d92bc9848325b1514f629d300405