### PR TITLE
Add landmarks to websocket payload

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -359,3 +359,10 @@ and ensure ruff works with current version.
 - **Motivation / Decision**: integrate backend metrics to follow tech
   challenge.
 - **Next step**: none.
+
+### 2025-07-14  PR #40
+
+- **Summary**: WebSocket payload now includes landmarks list, frontend and tests updated.
+- **Stage**: implementation
+- **Motivation / Decision**: align message structure for pose viewer rendering.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -79,5 +79,5 @@
 - [x] Add MIT license file and reference it in README.
 - [x] Document public functions in scripts for clarity.
 - [x] Pin `websockets` dependency and update README accordingly.
-- [ ] Basic React frontend with PoseViewer and WebSocket hook.
-- [ ] Add backend analytics module with WebSocket integration.
+- [x] Basic React frontend with PoseViewer and WebSocket hook.
+- [x] Add backend analytics module with WebSocket integration.

--- a/frontend/src/__tests__/MetricsPanel.test.tsx
+++ b/frontend/src/__tests__/MetricsPanel.test.tsx
@@ -3,6 +3,6 @@ import MetricsPanel from '../components/MetricsPanel';
 import '@testing-library/jest-dom';
 
 test('displays balance metric', () => {
-  render(<MetricsPanel data={{ balance_score: 0.5 }} />);
+  render(<MetricsPanel data={{ balance: 0.5 }} />);
   expect(screen.getByText(/Balance: 0\.50/)).toBeInTheDocument();
 });

--- a/frontend/src/components/MetricsPanel.tsx
+++ b/frontend/src/components/MetricsPanel.tsx
@@ -3,7 +3,7 @@ interface MetricsPanelProps {
 }
 
 const MetricsPanel: React.FC<MetricsPanelProps> = ({ data }) => {
-  const balance = data?.balance_score ?? 0;
+  const balance = data?.balance ?? 0;
   return (
     <div className="metrics-panel">Balance: {balance.toFixed(2)}</div>
   );

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,17 @@
+from backend.server import build_payload
+
+
+def test_build_payload_format():
+    lms = {
+        'hip': {'x': 0.1, 'y': 0.2},
+        'knee': {'x': 0.3, 'y': 0.4},
+        'ankle': {'x': 0.5, 'y': 0.6},
+        'left_hip': {'x': 0.1, 'y': 0.2},
+        'right_hip': {'x': 0.2, 'y': 0.2},
+    }
+    payload = build_payload(lms)
+    assert isinstance(payload['landmarks'], list)
+    assert payload['landmarks'][0] == {'x': 0.1, 'y': 0.2}
+    metrics = payload['metrics']
+    assert {'knee_angle', 'balance'} <= metrics.keys()
+


### PR DESCRIPTION
## Summary
- include raw landmark coordinates in backend websocket payload
- update frontend metrics panel to use `balance` key
- add tests for new websocket payload format
- mark roadmap items complete and note the update

## Testing
- `make lint`
- `make lint-docs`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6874d92db5888325ac56951a2ff4ec9a