### PR TITLE
Update README with running guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.15 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.16 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -73,7 +73,7 @@ Follow the coding rules described in `CODING_RULES.md`.
     - Run `make check-versions` when changing dependencies to
       verify pinned versions exist.
     - Python code under `scripts/` and `tests/` is linted with `ruff` via `make lint`.
-
+    - `make test` expects dependencies from `.codex/setup.sh`.
 3. **Style rules** – keep code formatted (`black`, `prettier`,
    `dart format`, etc.) and Markdown lines ≤ 80 chars;
    avoid multiple consecutive blank lines (markdownlint MD012);

--- a/NOTES.md
+++ b/NOTES.md
@@ -359,3 +359,12 @@ and ensure ruff works with current version.
 - **Motivation / Decision**: integrate backend metrics to follow tech
   challenge.
 - **Next step**: none.
+
+## 2025-07-14  PR #40
+
+- **Summary**: added running instructions to README and updated AGENTS with
+  test setup bullet.
+- **Stage**: documentation
+- **Motivation / Decision**: clarify how to start backend and frontend locally
+  and note that tests require dependencies from setup.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ npm run build
 npm test
 ```
 
+## Running locally
+
+Start the backend with:
+```bash
+python -m backend.server
+```
+
+Build and serve the frontend in another terminal:
+```bash
+npm run build
+python -m http.server --directory frontend/dist 8080
+```
+Then open http://localhost:8080 in your browser.
+
+
 ## License
 
 PoseDetection is released under the MIT License. See [LICENSE](LICENSE).

--- a/TODO.md
+++ b/TODO.md
@@ -79,5 +79,6 @@
 - [x] Add MIT license file and reference it in README.
 - [x] Document public functions in scripts for clarity.
 - [x] Pin `websockets` dependency and update README accordingly.
-- [ ] Basic React frontend with PoseViewer and WebSocket hook.
-- [ ] Add backend analytics module with WebSocket integration.
+- [x] Basic React frontend with PoseViewer and WebSocket hook.
+- [x] Add backend analytics module with WebSocket integration.
+- [ ] Document how to run the backend and frontend locally.


### PR DESCRIPTION
## Summary
- add new section showing how to run backend and frontend
- clarify in AGENTS that `make test` needs dependencies from `.codex/setup.sh`
- tick TODO items for frontend and backend analytics
- note update in engineering log

## Testing
- `make lint-docs`
- `.codex/setup.sh`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6874d93160c08325b792c7dd2b3f7fa0