### PR TITLE
Tick TODO for local run docs

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -408,3 +408,10 @@ and ensure ruff works with current version.
 - **Stage**: maintenance
 - **Motivation / Decision**: keep roadmap accurate now that features exist.
 - **Next step**: verify integration in upcoming releases.
+### 2025-07-14  PR #46
+
+- **Summary**: ticked roadmap item documenting how to run backend and frontend.
+- **Stage**: documentation
+- **Motivation / Decision**: README already explains local setup; keep TODO aligned.
+- **Next step**: none.
+

--- a/TODO.md
+++ b/TODO.md
@@ -79,7 +79,7 @@
 - [x] Add MIT license file and reference it in README.
 - [x] Document public functions in scripts for clarity.
 - [x] Pin `websockets` dependency and update README accordingly.
-- [ ] Document how to run the backend and frontend locally.
+- [x] Document how to run the backend and frontend locally.
 - [x] Add server entrypoint and startup test for backend.
 - [x] Basic React frontend with PoseViewer and WebSocket hook.
 - [x] Add backend analytics module with WebSocket integration.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,4 +1,7 @@
 from backend.server import build_payload
+import subprocess
+import sys
+import time
 
 
 def test_build_payload_format():
@@ -14,10 +17,6 @@ def test_build_payload_format():
     assert payload['landmarks'][0] == {'x': 0.1, 'y': 0.2}
     metrics = payload['metrics']
     assert {'knee_angle', 'balance'} <= metrics.keys()
-
-import sys
-import subprocess
-import time
 
 
 def test_server_starts():


### PR DESCRIPTION
## Summary
- mark "Document how to run the backend and frontend locally" as done
- note the completion in NOTES
- move imports in `test_server` to satisfy linter

## Testing
- `make lint-docs`
- `./.codex/setup.sh`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6874ddb09f60832595f42109689f911f