### PR TITLE
Improve README code block spacing

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -408,3 +408,11 @@ and ensure ruff works with current version.
 - **Stage**: maintenance
 - **Motivation / Decision**: keep roadmap accurate now that features exist.
 - **Next step**: verify integration in upcoming releases.
+
+### 2025-07-20  PR #46
+
+- **Summary**: improved README formatting around local run instructions and fixed ruff import order.
+- **Stage**: maintenance
+- **Motivation / Decision**: docs needed spacing tweaks and lint failed; moved imports to top.
+- **Next step**: none.
+

--- a/README.md
+++ b/README.md
@@ -56,16 +56,19 @@ npm test
 ## Running locally
 
 Start the backend with:
+
 ```bash
 python -m backend.server
 ```
 
 Build and serve the frontend in another terminal:
+
 ```bash
 npm run build
 python -m http.server --directory frontend/dist 8080
 ```
-Then open http://localhost:8080 in your browser.
+
+Then open [http://localhost:8080](http://localhost:8080) in your browser.
 
 ## Backend
 

--- a/TODO.md
+++ b/TODO.md
@@ -79,7 +79,7 @@
 - [x] Add MIT license file and reference it in README.
 - [x] Document public functions in scripts for clarity.
 - [x] Pin `websockets` dependency and update README accordingly.
-- [ ] Document how to run the backend and frontend locally.
+- [x] Document how to run the backend and frontend locally.
 - [x] Add server entrypoint and startup test for backend.
 - [x] Basic React frontend with PoseViewer and WebSocket hook.
 - [x] Add backend analytics module with WebSocket integration.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,7 @@
 from backend.server import build_payload
-
+import subprocess
+import sys
+import time
 
 def test_build_payload_format():
     lms = {
@@ -14,10 +16,6 @@ def test_build_payload_format():
     assert payload['landmarks'][0] == {'x': 0.1, 'y': 0.2}
     metrics = payload['metrics']
     assert {'knee_angle', 'balance'} <= metrics.keys()
-
-import sys
-import subprocess
-import time
 
 
 def test_server_starts():


### PR DESCRIPTION
## Summary
- fix spacing for local setup section in README
- use markdown link for localhost
- fix ruff lint error by moving imports to top of tests
- mark TODO for local run docs done
- note changes in NOTES

## Testing
- `make lint-docs`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6874ddac1630832599350605d3f0379f