### PR TITLE
Update markdown rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.16 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.17 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -162,6 +162,7 @@ jobs:
 - ≤ 20 logical LOC per function, ≤ 2 nesting levels.
 - Surround headings / lists / fenced code with a blank line
   (markdownlint MD022, MD032).
+- Surround fenced code blocks with a blank line (markdownlint MD031).
 - **No trailing spaces.** Run `git diff --check` or `make lint-docs`.
 - Wrap identifiers like `__init__` in back‑ticks to avoid MD050.
 - Each public API carries a short doc‑comment.
@@ -170,6 +171,7 @@ jobs:
 - Use `-` for bullet lists.
 - Indent nested bullet lists by two spaces relative to their parent item.
 - Use a normal space after `#` in headings.
+- Avoid bare URLs; format them as Markdown links (MD034).
 - Avoid inline HTML.
 
 ---

--- a/NOTES.md
+++ b/NOTES.md
@@ -408,3 +408,10 @@ and ensure ruff works with current version.
 - **Stage**: maintenance
 - **Motivation / Decision**: keep roadmap accurate now that features exist.
 - **Next step**: verify integration in upcoming releases.
+
+### 2025-07-19  PR #draft
+
+- **Summary**: bumped AGENTS guide to v1.17 with MD031 and MD034 notes.
+- **Stage**: documentation
+- **Motivation / Decision**: keep coding style rules accurate.
+- **Next step**: none.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,4 +1,7 @@
 from backend.server import build_payload
+import sys
+import subprocess
+import time
 
 
 def test_build_payload_format():
@@ -14,10 +17,6 @@ def test_build_payload_format():
     assert payload['landmarks'][0] == {'x': 0.1, 'y': 0.2}
     metrics = payload['metrics']
     assert {'knee_angle', 'balance'} <= metrics.keys()
-
-import sys
-import subprocess
-import time
 
 
 def test_server_starts():


### PR DESCRIPTION
## Summary
- bump AGENTS guide to v1.17
- document MD031 and MD034 rules
- reorder imports in tests so lint passes

## Testing
- `make lint-docs`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6874ddaf402c8325b518dca26bde92cf