### PR TITLE
Add docs build with Sphinx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 venv/
 node_modules/
 env/
+docs/_build/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.17 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.18 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -72,6 +72,7 @@ Follow the coding rules described in `CODING_RULES.md`.
     - Always run `make lint-docs` after editing any Markdown file to avoid CI failures.
     - Run `make check-versions` when changing dependencies to
       verify pinned versions exist.
+    - Run `make docs` to build the HTML docs into `docs/_build`.
     - Python code under `scripts/` and `tests/` is linted with `ruff` via `make lint`.
     - `make test` expects dependencies from `.codex/setup.sh`.
 3. **Style rules** – keep code formatted (`black`, `prettier`,

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint lint-docs test generate
+.PHONY: lint lint-docs test generate docs
 
 lint:
 	npx --yes markdownlint-cli **/*.md
@@ -24,3 +24,6 @@ update-todo-date:
 
 check-versions:
 	python scripts/check_versions.py
+
+docs:
+	$(MAKE) -C docs html

--- a/NOTES.md
+++ b/NOTES.md
@@ -435,3 +435,10 @@ keep TODO aligned.
 - **Stage**: maintenance
 - **Motivation / Decision**: keep NOTES lint-compliant.
 - **Next step**: none.
+
+### 2025-07-14  PR #50
+
+- **Summary**: added Sphinx docs build and make docs command.
+- **Stage**: implementation
+- **Motivation / Decision**: roadmap item for full doc build; need local HTML docs.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ Start the API server with:
 python -m backend.server
 ```
 
+## Building docs
+
+Generate the HTML documentation with:
+
+```bash
+make docs
+```
+
+The output appears in `docs/_build/html`.
+
 ## License
 
 PoseDetection is released under the MIT License. See [LICENSE](LICENSE).

--- a/TODO.md
+++ b/TODO.md
@@ -33,7 +33,7 @@
 ## 2 · Documentation & CI
 
 - [x] Write README quick‑start (clone → setup → test)
-- [ ] Add full doc build (Sphinx / JSDoc / dart‑doc as applicable)
+- [x] Add full doc build (Sphinx / JSDoc / dart‑doc as applicable)
 - [x] Integrate secret‑detection helper step in CI (`has_token` pattern)
 - [ ] Extend CI matrix for all runtimes (Python, Node, Dart, Rust, …)
 - [ ] Add Actionlint + markdown‑link‑check jobs and pin their versions

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,30 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'PoseDetection'
+copyright = '2025, Pose Team'
+author = 'Pose Team'
+
+version = '0.1'
+release = '0.1'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = []
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+language = 'en'
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,20 @@
+.. PoseDetection documentation master file, created by
+   sphinx-quickstart on Mon Jul 14 10:57:30 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to PoseDetection's documentation!
+#########################################
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+##################
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mediapipe==0.10.13
 ruff==0.4.4
 websockets==15.0.1
 httpx==0.27.0
+sphinx==7.2.6


### PR DESCRIPTION
## Summary
- set up Sphinx docs under `docs/`
- ignore build artefacts
- add `make docs` target
- document docs build in README
- tick roadmap item and log the change
- mention docs build in contributor guide

## Testing
- `make check-versions`
- `make lint`
- `make test`
- `make docs`


------
https://chatgpt.com/codex/tasks/task_e_6874e21533f48325806ce764707db790