### PR TITLE
Add pose classification metric

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -449,3 +449,11 @@ keep TODO aligned.
 - **Stage**: implementation
 - **Motivation / Decision**: roadmap item for full doc build; need local HTML docs.
 - **Next step**: none.
+
+### 2025-07-14  PR #52
+
+- **Summary**: added pose classification metric and updated server, UI and docs.
+- **Stage**: implementation
+- **Motivation / Decision**: feature request to distinguish standing vs sitting
+  using hip and knee angles.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ The Python dependencies install `mediapipe==0.10.13` and
 ### Backend server
 
 Run `python -m backend.main` to launch the FastAPI server. The `/pose`
-WebSocket streams pose keypoints extracted from each video frame.
+WebSocket streams pose keypoints extracted from each video frame. The
+payload includes simple analytics like knee angle, balance and a
+``pose_class`` field indicating ``standing`` or ``sitting``.
 
 ## Development
 

--- a/TODO.md
+++ b/TODO.md
@@ -87,3 +87,4 @@
 - [x] Add backend analytics module with WebSocket integration.
 - [x] Add MediaPipe pose detector and FastAPI server with `/pose` WebSocket.
 - [x] Support side-specific landmarks in `extract_pose_metrics`.
+- [x] Add pose classification metric and expose it in server and UI.

--- a/backend/server.py
+++ b/backend/server.py
@@ -16,7 +16,10 @@ mp_pose = mp.solutions.pose.Pose()
 
 
 def build_payload(lms: Dict[str, Dict[str, float]]) -> Dict[str, Any]:
-    """Return WebSocket payload with landmarks list and metrics."""
+    """Return WebSocket payload with landmarks list and metrics.
+
+    The metrics dictionary now includes ``pose_class``.
+    """
     metrics = extract_pose_metrics(lms)
     return {"landmarks": list(lms.values()), "metrics": metrics}
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,10 @@ from backend.analytics import extract_pose_metrics
 metrics = extract_pose_metrics(landmarks)
 ```
 
+The returned dictionary contains ``knee_angle`` in degrees,
+``balance`` between the hips and ``pose_class`` which is either
+``"standing"`` or ``"sitting"`` when the angles can be computed.
+
 Start the backend server with:
 
 ```bash

--- a/frontend/src/__tests__/MetricsPanel.test.tsx
+++ b/frontend/src/__tests__/MetricsPanel.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import MetricsPanel from '../components/MetricsPanel';
 import '@testing-library/jest-dom';
 
-test('displays balance metric', () => {
-  render(<MetricsPanel data={{ balance: 0.5 }} />);
-  expect(screen.getByText(/Balance: 0\.50/)).toBeInTheDocument();
+test('displays balance and pose', () => {
+  render(<MetricsPanel data={{ balance: 0.5, pose_class: 'standing' }} />);
+  expect(screen.getByText(/Balance: 0\.50 Pose: standing/)).toBeInTheDocument();
 });

--- a/frontend/src/components/MetricsPanel.tsx
+++ b/frontend/src/components/MetricsPanel.tsx
@@ -1,11 +1,12 @@
 interface MetricsPanelProps {
-  data?: Record<string, number>;
+  data?: Record<string, number | string>;
 }
 
 const MetricsPanel: React.FC<MetricsPanelProps> = ({ data }) => {
-  const balance = data?.balance ?? 0;
+  const balance = Number(data?.balance ?? 0);
+  const pose = data?.pose_class ?? '';
   return (
-    <div className="metrics-panel">Balance: {balance.toFixed(2)}</div>
+    <div className="metrics-panel">Balance: {balance.toFixed(2)} Pose: {pose}</div>
   );
 };
 

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -5,7 +5,7 @@ import MetricsPanel from './MetricsPanel';
 
 interface PoseData {
   landmarks: Point[];
-  metrics: Record<string, number>;
+  metrics: Record<string, number | string>;
 }
 
 const PoseViewer: React.FC = () => {

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,7 +1,12 @@
 import math
 import pytest
 
-from backend.analytics import calculate_angle, balance_score, extract_pose_metrics
+from backend.analytics import (
+    calculate_angle,
+    balance_score,
+    extract_pose_metrics,
+    pose_classification,
+)
 
 
 def test_calculate_angle_basic():
@@ -27,6 +32,7 @@ def test_extract_pose_metrics_missing_landmarks():
     metrics = extract_pose_metrics({})
     assert math.isnan(metrics['knee_angle'])
     assert math.isnan(metrics['balance'])
+    assert metrics['pose_class'] == 'unknown'
 
 
 def test_extract_pose_metrics_left_side():
@@ -39,6 +45,7 @@ def test_extract_pose_metrics_left_side():
     metrics = extract_pose_metrics(lms)
     assert not math.isnan(metrics['knee_angle'])
     assert not math.isnan(metrics['balance'])
+    assert metrics['pose_class'] in {'standing', 'sitting', 'unknown'}
 
 
 def test_extract_pose_metrics_right_side():
@@ -51,3 +58,16 @@ def test_extract_pose_metrics_right_side():
     metrics = extract_pose_metrics(lms)
     assert not math.isnan(metrics['knee_angle'])
     assert not math.isnan(metrics['balance'])
+    assert metrics['pose_class'] in {'standing', 'sitting', 'unknown'}
+
+
+def test_pose_classification():
+    lms = {
+        'left_shoulder': {'x': 0.0, 'y': 0.0},
+        'left_hip': {'x': 0.0, 'y': 1.0},
+        'left_knee': {'x': 0.0, 'y': 2.0},
+        'left_ankle': {'x': 0.0, 'y': 3.0},
+    }
+    assert pose_classification(lms) == 'standing'
+    lms['left_knee']['x'] = 1.0
+    assert pose_classification(lms) == 'sitting'

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,7 +16,7 @@ def test_build_payload_format():
     assert isinstance(payload['landmarks'], list)
     assert payload['landmarks'][0] == {'x': 0.1, 'y': 0.2}
     metrics = payload['metrics']
-    assert {'knee_angle', 'balance'} <= metrics.keys()
+    assert {'knee_angle', 'balance', 'pose_class'} <= metrics.keys()
 
 
 def test_server_starts():


### PR DESCRIPTION
## Summary
- classify pose as standing or sitting in analytics
- expose pose_class in server payloads
- show new metric in MetricsPanel
- test analytics, server and UI
- document pose_class
- update roadmap and notes

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6874e76fda9883259c11943b70d5a861