### PR TITLE
Add pre-commit hooks and docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      - id: ruff
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pre-commit/mirrors-markdownlint-cli
+    rev: v0.39.0
+    hooks:
+      - id: markdownlint-cli

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.18 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.19 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -50,6 +50,7 @@ Follow the coding rules described in `CODING_RULES.md`.
 3. Verify the **secret‑detection helper step** in
     `.github/workflows/ci.yml` (see § 4) so forks without secrets still pass.
 4. On the first PR, update README badges to point at your fork (owner/repo).
+5. Install `pre-commit` and run `pre-commit install` to enable the git hook.
 
 ---
 
@@ -62,6 +63,7 @@ Follow the coding rules described in `CODING_RULES.md`.
    ```bash
    make lint                  # all format / static‑analysis steps
    make test                  # unit/integration tests with coverage ≥80%
+   pre-commit run --files <changed>
    ```
 
     - For docs-only changes run `make lint` (or `make lint-docs`) before committing.

--- a/NOTES.md
+++ b/NOTES.md
@@ -449,3 +449,10 @@ keep TODO aligned.
 - **Stage**: implementation
 - **Motivation / Decision**: roadmap item for full doc build; need local HTML docs.
 - **Next step**: none.
+
+### 2025-07-14  PR #52
+
+- **Summary**: added pre-commit config with ruff, black and markdownlint; updated docs.
+- **Stage**: implementation
+- **Motivation / Decision**: automate linting per TODO item; pre-commit runs before each commit.
+- **Next step**: integrate actionlint hook.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ WebSocket streams pose keypoints extracted from each video frame.
 
 Run `make lint` to check Markdown and Python code style (ruff).
 Run `make test` to execute the future test-suite.
+Install pre-commit and run `pre-commit install` so ruff, black and
+markdownlint run automatically before each commit.
 
 ## Setup
 

--- a/TODO.md
+++ b/TODO.md
@@ -41,7 +41,8 @@
 
 ## 3 · Quality & automation
 
-- [ ] Add pre-commit hooks (formatters, linters, markdownlint, actionlint)
+- [x] Add pre-commit hooks (formatters, linters, markdownlint, actionlint)
+- [ ] Add actionlint to the pre-commit configuration
 - [x] Enforce coverage threshold (≥ 80 % branch, exclude `/generated/**`)
 - [ ] Add linters for conflict markers, trailing spaces and NOTES ordering
 - [ ] Introduce dependabot / Renovate with the version‑pin policy from


### PR DESCRIPTION
## Summary
- configure pre-commit with ruff, black and markdownlint
- instruct contributors to install and run pre-commit
- document hook usage in README development section
- tick TODO item for pre-commit hooks and log the work in NOTES

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6874e773b5b88325834eed3ca01dcec5