### PR TITLE
Add version check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       md_only: ${{ steps.filter.outputs.md_only }}
+      deps: ${{ steps.filter.outputs.deps }}
     steps:
       - uses: actions/checkout@v4
       - id: filter
@@ -15,6 +16,10 @@ jobs:
           filters: |
             md_only:
               - '**/*.md'
+            deps:
+              - 'requirements.txt'
+              - 'package.json'
+              - 'package-lock.json'
 
   secret-check:
     runs-on: ubuntu-latest
@@ -33,6 +38,14 @@ jobs:
       - run: |
           npx --yes markdownlint-cli '**/*.md'
           grep -R --line-number -E '<{7}|={7}|>{7}' --exclude=ci.yml . && exit 1 || echo "No conflict markers"
+
+  check-versions:
+    needs: [changes]
+    if: needs.changes.outputs.deps == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make check-versions
 
   test:
     needs: [changes]

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ venv/
 node_modules/
 env/
 docs/_build/
+.coverage
+.python-version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,9 @@ Follow the coding rules described in `CODING_RULES.md`.
     - After editing `TODO.md` also run `make update-todo-date` to refresh
       the header date.
     - Always run `make lint-docs` after editing any Markdown file to avoid CI failures.
-    - Run `make check-versions` when changing dependencies to
-      verify pinned versions exist.
+     - Run `make check-versions` when changing dependencies to
+       verify pinned versions exist. CI runs this automatically when
+       `requirements.txt`, `package.json` or `package-lock.json` change.
     - Run `make docs` to build the HTML docs into `docs/_build`.
     - Python code under `scripts/` and `tests/` is linted with `ruff` via `make lint`.
     - `make test` expects dependencies from `.codex/setup.sh`.

--- a/NOTES.md
+++ b/NOTES.md
@@ -449,3 +449,9 @@ keep TODO aligned.
 - **Stage**: implementation
 - **Motivation / Decision**: roadmap item for full doc build; need local HTML docs.
 - **Next step**: none.
+### 2025-07-14  PR #52
+
+- **Summary**: added CI job to check dependency versions.
+- **Stage**: maintenance
+- **Motivation / Decision**: ensure pinned packages exist; tick roadmap item.
+- **Next step**: monitor results and update versions when needed.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ WebSocket streams pose keypoints extracted from each video frame.
 
 Run `make lint` to check Markdown and Python code style (ruff).
 Run `make test` to execute the future test-suite.
+CI runs `make check-versions` whenever dependency files change to
+ensure pinned versions are valid.
 
 ## Setup
 

--- a/TODO.md
+++ b/TODO.md
@@ -71,7 +71,7 @@
 - [x] Remind to run `make lint-docs` after editing NOTES or TODO.
 - [x] Emphasise linting all Markdown files in AGENTS guide.
 - [x] Mention CODING_RULES doc link in AGENTS guide.
-- [ ] Regularly verify dependency versions for compatibility issues.
+- [x] Regularly verify dependency versions for compatibility issues.
 - [x] Provide script to check pinned package versions exist.
 - [x] Update TypeScript to 5.5.4 in package.json.
 - [x] Clarify nested bullet indentation rule in AGENTS guide.


### PR DESCRIPTION
## Summary
- add `check-versions` job in CI
- note automatic version validation in AGENTS guide
- document the check in README
- mark roadmap item done and log change in NOTES
- ignore `.coverage` and `.python-version`

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6874e76bebbc8325a9cf0025f4735b3b