### PR TITLE
Add lint + link check jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,16 @@ jobs:
           npx --yes markdownlint-cli '**/*.md'
           grep -R --line-number -E '<{7}|={7}|>{7}' --exclude=ci.yml . && exit 1 || echo "No conflict markers"
 
+  markdown-link-check:
+    needs: [changes]
+    if: needs.changes.outputs.md_only == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lycheeverse/lychee-action@v2.4.1
+        with:
+          args: --no-progress --verbose '**/*.md'
+
   check-versions:
     needs: [changes]
     if: needs.changes.outputs.deps == 'true'
@@ -46,6 +56,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: make check-versions
+
+  actionlint:
+    needs: [changes]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/actionlint@v1.7.7
 
   test:
     needs: [changes]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.19 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.20 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -140,6 +140,23 @@ jobs:
           npx --yes markdownlint-cli '**/*.md'
           grep -R --line-number -E '<{7}|={7}|>{7}' --exclude=ci.yml . && exit 1 || echo "No conflict markers"
 
+  markdown-link-check:
+    needs: [changes]
+    if: needs.changes.outputs.md_only == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lycheeverse/lychee-action@v2.4.1
+        with:
+          args: --no-progress --verbose '**/*.md'
+
+  actionlint:
+    needs: [changes]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/actionlint@v1.7.7
+
   test:
     needs: [changes]
     if: needs.changes.outputs.md_only != 'true'
@@ -153,10 +170,10 @@ jobs:
 ```
 <!-- markdownlint-enable MD013 -->
 
-- **Docs‑only changes** run in seconds (`lint-docs`).
-- **Code changes** run full lint + tests (`test`).
-- Add job matrices (multi‑language), action‑lint, or deployment later—
-  guardrails above already catch the 90 % most common issues.
+- **Docs‑only changes** run in seconds (`lint-docs` + `markdown-link-check`).
+- **Code changes** run full lint + tests (`test`) and `actionlint`.
+- Add job matrices or deployments later—guardrails above already catch the 90 %
+  most common issues.
 
 ---
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -544,3 +544,10 @@ updated requirements and workflow.
 - **Motivation / Decision**: feature request to distinguish standing vs sitting
   using hip and knee angles.
 - **Next step**: none.
+
+### 2025-07-14  PR #64
+
+- **Summary**: added actionlint and markdown link check jobs in CI.
+- **Stage**: maintenance
+- **Motivation / Decision**: fulfill TODO item for workflow validation and link checking.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -36,7 +36,7 @@
 - [x] Add full doc build (Sphinx / JSDoc / dart‑doc as applicable)
 - [x] Integrate secret‑detection helper step in CI (`has_token` pattern)
 - [ ] Extend CI matrix for all runtimes (Python, Node, Dart, Rust, …)
-- [ ] Add Actionlint + markdown‑link‑check jobs and pin their versions
+- [x] Add Actionlint + markdown‑link‑check jobs and pin their versions
 - [ ] Publish docs to GitHub Pages when `GH_PAGES_TOKEN` is present
 
 ## 3 · Quality & automation


### PR DESCRIPTION
## Summary
- add `actionlint` and `markdown-link-check` jobs to workflow
- document new jobs in contributor guide
- record the update in NOTES and tick TODO

## Testing
- `make lint`
- `make test`
- `make lint-docs`


------
https://chatgpt.com/codex/tasks/task_e_6874ee2d2d588325bfa5bcf7f3f846fa