### PR TITLE
Fix quoting for secret check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       has_pages_token: ${{ steps.echo.outputs.has_pages }}
     steps:
       - id: echo
-        run: echo "has_pages=${{ secrets.GH_PAGES_TOKEN != '' }}" >> $GITHUB_OUTPUT
+        run: echo "has_pages=${{ secrets.GH_PAGES_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
 
   lint-docs:
     needs: [changes]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.20 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.21 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -130,7 +130,7 @@ jobs:
       has_pages_token: ${{ steps.echo.outputs.has_pages }}
     steps:
       - id: echo         # returns 'true' / 'false'
-        run: echo "has_pages=${{ secrets.GH_PAGES_TOKEN != '' }}" >> $GITHUB_OUTPUT
+        run: echo "has_pages=${{ secrets.GH_PAGES_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
 
   lint-docs:
     needs: [changes]

--- a/NOTES.md
+++ b/NOTES.md
@@ -566,3 +566,10 @@ updated requirements and workflow.
 - **Stage**: documentation
 - **Motivation / Decision**: keep instructions aligned with server entry point.
 - **Next step**: none.
+
+### 2025-07-14  PR #68
+
+- **Summary**: fixed quoting in CI secret-check step.
+- **Stage**: maintenance
+- **Motivation / Decision**: ensure variable expansion works in GitHub Actions.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -89,3 +89,4 @@
 - [x] Add MediaPipe pose detector and FastAPI server with `/pose` WebSocket.
 - [x] Support side-specific landmarks in `extract_pose_metrics`.
 - [x] Add pose classification metric and expose it in server and UI.
+- [x] Quote `$GITHUB_OUTPUT` in secret-check step of CI workflow.


### PR DESCRIPTION
## Summary
- quote `$GITHUB_OUTPUT` in the workflow
- document the change and bump AGENTS guide to v1.21
- log the fix in NOTES
- record the completed task in TODO

## Testing
- `make lint`
- `make test`
- *(failed: `pre-commit run --files .github/workflows/ci.yml AGENTS.md NOTES.md TODO.md`)*

------
https://chatgpt.com/codex/tasks/task_e_6874f38bd7a88325b628bc32e8473841