### PR TITLE
Add lychee ignore and workflow tweak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: lycheeverse/lychee-action@v2.4.1
         with:
-          args: --no-progress --verbose '**/*.md'
+          args: --no-progress --verbose './**/*.md'
 
   check-versions:
     needs: [changes]

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,3 @@
+http://localhost:*
+https://localhost:*
+ws://localhost:*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.21 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.22 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -174,7 +174,8 @@ jobs:
 
 - **Docs‑only changes** run in seconds (`lint-docs` + `markdown-link-check`).
 - Use `<!-- lychee skip -->` after local URLs (e.g. `http://localhost:`)
-  so lychee doesn’t fail.
+  so lychee doesn’t fail. Localhost patterns are also
+  ignored via `.lycheeignore`.
 - **Code changes** run full lint + tests (`test`) and `actionlint`.
 - Add job matrices or deployments later—guardrails above already catch the 90 %
   most common issues.

--- a/NOTES.md
+++ b/NOTES.md
@@ -586,3 +586,10 @@ updated requirements and workflow.
 - **Stage**: maintenance
 - **Motivation / Decision**: keep docs lint-compliant.
 - **Next step**: none.
+
+### 2025-07-14  PR #71
+
+- **Summary**: added `.lycheeignore` for localhost links and tweaked CI arguments.
+- **Stage**: maintenance
+- **Motivation / Decision**: keep markdown link check stable.
+- **Next step**: none.


### PR DESCRIPTION
## Summary
- allow link checker to skip localhost links via `.lycheeignore`
- use glob path `'./**/*.md'` for lychee
- document new ignore file in AGENTS

## Testing
- `make lint`
- `make test`
- `pre-commit run --files .github/workflows/ci.yml AGENTS.md NOTES.md .lycheeignore` *(fails: asks for GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_6874f831ef608325a6b9c00f309564f6