### PR TITLE
Fix coverage requirement

### DIFF
--- a/CODING_RULES.md
+++ b/CODING_RULES.md
@@ -13,7 +13,7 @@
 11 Dependency tree must contain 0 critical/high‑CVEs
 12 Run auto‑formatter, linter, and SAST before output
 13 Unit‑test template with ≥1 positive and ≥1 negative case per public API
-14 Achieve ≥90 % branch coverage and cyclomatic complexity ≤15 per file
+14 Achieve ≥80 % branch coverage and cyclomatic complexity ≤15 per file
 15 Emit lightweight performance/log hooks for three actionable metrics
 16 Full static type annotations; type checker passes with 0 errors
 17 Use context‑managed resource handling; 0 leak warnings in SAST

--- a/NOTES.md
+++ b/NOTES.md
@@ -606,3 +606,10 @@ updated requirements and workflow.
 - **Stage**: implementation
 - **Motivation / Decision**: avoid missing hook installation instructions.
 - **Next step**: none.
+
+### 2025-07-14  PR #
+
+- **Summary**: lowered branch coverage requirement in CODING_RULES to 80%.
+- **Stage**: documentation
+- **Motivation / Decision**: align coding rules with CI coverage threshold.
+- **Next step**: none.


### PR DESCRIPTION
## Summary
- lower the branch coverage requirement in CODING_RULES to 80%
- log the change in NOTES

## Testing
- `make lint-docs`
- `pre-commit run --files CODING_RULES.md NOTES.md` *(fails: asks for GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_687500f1c6d483259433b675ab2ebfcd