### PR TITLE
Update TODO and NOTES for pre-commit hooks

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -625,3 +625,10 @@ updated requirements and workflow.
 - **Stage**: documentation
 - **Motivation / Decision**: remove outdated sentence to reflect repo status.
 - **Next step**: none.
+
+### 2025-07-15  PR #77
+
+- **Summary**: setup script now prefetches pre-commit hooks.
+- **Stage**: maintenance
+- **Motivation / Decision**: fetch hooks during setup so later runs work offline.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO – Road‑map (last updated: 2025-07-14)
+# TODO – Road‑map (last updated: 2025-07-15)
 
 > *Record only high‑level milestones here; break micro‑tasks out into Issues.*  
 > **When you finish a task, tick it and append a short NOTE entry
@@ -47,6 +47,7 @@
 - [ ] Add linters for conflict markers, trailing spaces and NOTES ordering
 - [ ] Introduce dependabot / Renovate with the version‑pin policy from
       `AGENTS.md`
+- [ ] Prefetch pre-commit hooks during setup so offline runs work.
 
 ## 4 · Stretch goals
 


### PR DESCRIPTION
## Summary
- record future improvement to prefetch hooks in TODO
- note that setup now pulls pre-commit hooks so they are cached

## Testing
- `make lint-docs`


------
https://chatgpt.com/codex/tasks/task_e_6875efcc58e08325b0c547b4091f7715