### PR TITLE
Install precommit hooks in setup

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -33,6 +33,11 @@ PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "$PROJECT_ROOT"
 python3 -m pip install -r requirements.txt
 python3 -m pip install pre-commit
+# install hooks into the shared cache while network is available
+if [ -f .pre-commit-config.yaml ]; then
+  pre-commit install --install-hooks --overwrite
+  pre-commit run --all-files
+fi
 npm install
 
 echo "Setup complete"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,8 @@ Follow the coding rules described in `CODING_RULES.md`.
 3. Verify the **secret‑detection helper step** in
     `.github/workflows/ci.yml` (see § 4) so forks without secrets still pass.
 4. On the first PR, update README badges to point at your fork (owner/repo).
-5. `.codex/setup.sh` installs `pre-commit`; run `pre-commit install` to enable
-   the git hook.
+5. `.codex/setup.sh` installs `pre-commit` and sets up the hooks automatically
+   on the first run.
 
 ---
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -625,3 +625,11 @@ updated requirements and workflow.
 - **Stage**: documentation
 - **Motivation / Decision**: remove outdated sentence to reflect repo status.
 - **Next step**: none.
+
+### 2025-07-15  PR #77
+
+- **Summary**: setup script installs pre-commit hooks and runs them once.
+- **Stage**: implementation
+- **Motivation / Decision**: ensure hooks are cached while network is
+  available.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ Run `make lint` to check Markdown and Python code style (ruff).
 Run `make test` to execute the test-suite.
 CI runs `make check-versions` whenever dependency files change to
 ensure pinned versions are valid.
-Run `pre-commit install` once so ruff, black and markdownlint run
-automatically before each commit. The setup script already installs
-`pre-commit`.
+The setup script installs `pre-commit` and its hooks automatically and
+runs them once so ruff, black and markdownlint run before each commit.
 
 ## Setup
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO – Road‑map (last updated: 2025-07-14)
+# TODO – Road‑map (last updated: 2025-07-15)
 
 > *Record only high‑level milestones here; break micro‑tasks out into Issues.*  
 > **When you finish a task, tick it and append a short NOTE entry
@@ -91,3 +91,4 @@
 - [x] Add pose classification metric and expose it in server and UI.
 - [x] Quote `$GITHUB_OUTPUT` in secret-check step of CI workflow.
 - [x] Setup script installs `pre-commit` automatically.
+- [x] Setup script installs pre-commit hooks and runs them once.


### PR DESCRIPTION
## Summary
- ensure setup script installs pre-commit hooks and runs them once
- note automatic hook install in AGENTS and README
- tick TODO for hook installation
- log update in NOTES

## Testing
- `make lint`
- `make test`
- ❌ `pre-commit run --files .codex/setup.sh AGENTS.md NOTES.md README.md TODO.md` *(failed: asked for GitHub credentials)*


------
https://chatgpt.com/codex/tasks/task_e_6875efba26b883259f7258824b767d08