### PR TITLE
Introduce dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    versioning-strategy: increase
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    versioning-strategy: increase

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.24 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.25 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -97,6 +97,8 @@ Follow the coding rules described in `CODING_RULES.md`.
    `/docs` overrides this file.
 8. **Log discipline** – when a TODO item is ticked you **must** add the matching
    section in `NOTES.md` *in the same PR*; this keeps roadmap and log in‑sync.
+9. **Dependabot** – weekly checks update pinned versions in
+   `requirements.txt`, `package.json` and the CI workflow.
 
 ---
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -653,3 +653,10 @@ automatically and docs updated.
 - **Stage**: maintenance
 - **Motivation / Decision**: keep NOTES.md clean and pass markdownlint.
 - **Next step**: none.
+
+### 2025-07-15  PR #80
+
+- **Summary**: added weekly Dependabot config and updated docs.
+- **Stage**: implementation
+- **Motivation / Decision**: follow pin policy and automate updates.
+- **Next step**: monitor upcoming dependency PRs.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ CI runs `make check-versions` whenever dependency files change to
 ensure pinned versions are valid.
 Pre-commit hooks are installed automatically by `.codex/setup.sh`,
 so ruff, black and markdownlint run before each commit.
+Dependabot reviews `requirements.txt`, `package.json` and
+`package-lock.json` once a week and suggests version bumps.
 
 ## Setup
 

--- a/TODO.md
+++ b/TODO.md
@@ -45,7 +45,7 @@
 - [x] Add actionlint to the pre-commit configuration
 - [x] Enforce coverage threshold (≥ 80 % branch, exclude `/generated/**`)
 - [ ] Add linters for conflict markers, trailing spaces and NOTES ordering
-- [ ] Introduce dependabot / Renovate with the version‑pin policy from
+- [x] Introduce dependabot / Renovate with the version‑pin policy from
       `AGENTS.md`
 - [x] Prefetch pre-commit hooks during setup so offline runs work.
 


### PR DESCRIPTION
## Summary
- add weekly Dependabot config for pip, npm and GitHub Actions
- note Dependabot workflow in README and AGENTS guide
- check TODO off for Dependabot and log the decision

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6875faa330ec8325b78ccc94b78ac423