### PR TITLE
Implement lint notes checker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,10 @@ repos:
     rev: v1.7.7
     hooks:
       - id: actionlint
+  - repo: local
+    hooks:
+      - id: lint-notes
+        name: lint-notes
+        entry: python scripts/lint_notes.py
+        language: system
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.24 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.25 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -78,6 +78,7 @@ Follow the coding rules described in `CODING_RULES.md`.
       `requirements.txt`, `package.json` or `package-lock.json` change.
     - Run `make docs` to build the HTML docs into `docs/_build`.
     - Python code under `scripts/` and `tests/` is linted with `ruff` via `make lint`.
+    - `python scripts/lint_notes.py` enforces notes order and strips spaces.
     - GitHub Actions workflows are linted with
       `actionlint` pinned at v1.7.7 via pre-commit.
     - `make test` expects dependencies from `.codex/setup.sh`.

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 lint:
 	npx --yes markdownlint-cli **/*.md
 	ruff check scripts tests
+	python scripts/lint_notes.py
 
 lint-docs: lint
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -653,3 +653,10 @@ automatically and docs updated.
 - **Stage**: maintenance
 - **Motivation / Decision**: keep NOTES.md clean and pass markdownlint.
 - **Next step**: none.
+
+### 2025-07-15  PR #80
+
+- **Summary**: added lint_notes.py script and integrated into workflow.
+- **Stage**: implementation
+- **Motivation / Decision**: order enforcement and catching spaces/conflicts.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,8 @@
 # TODO – Road‑map (last updated: 2025-07-15)
 
-> *Record only high‑level milestones here; break micro‑tasks out into Issues.*  
+> *Record only high‑level milestones here; break micro‑tasks out into Issues.*
 > **When you finish a task, tick it and append a short NOTE entry
-> (see NOTES.md).**  
+> (see NOTES.md).**
 > Keep this list ordered by topic and **never reorder past items**.
 
 ## 0 · Project bootstrap
@@ -24,9 +24,9 @@
 *Repeat the five-bullet block below for every MVP feature A, B, C, ...*
 
 - [ ] Analyse source-of-truth docs; define acceptance criteria for feature A
-- [ ] Document assumptions / edge‑cases for feature A in `/docs` or README  
-- [ ] Implement feature A  
-- [ ] Add unit / integration tests for feature A  
+- [ ] Document assumptions / edge‑cases for feature A in `/docs` or README
+- [ ] Implement feature A
+- [ ] Add unit / integration tests for feature A
 - [ ] Wire CI quality gate (coverage ≥ 80 %, metric thresholds, etc.) that
       exits 1 on regression
 
@@ -44,7 +44,7 @@
 - [x] Add pre-commit hooks (formatters, linters, markdownlint, actionlint)
 - [x] Add actionlint to the pre-commit configuration
 - [x] Enforce coverage threshold (≥ 80 % branch, exclude `/generated/**`)
-- [ ] Add linters for conflict markers, trailing spaces and NOTES ordering
+- [x] Add linters for conflict markers, trailing spaces and NOTES ordering
 - [ ] Introduce dependabot / Renovate with the version‑pin policy from
       `AGENTS.md`
 - [x] Prefetch pre-commit hooks during setup so offline runs work.

--- a/scripts/lint_notes.py
+++ b/scripts/lint_notes.py
@@ -1,0 +1,68 @@
+import re
+import sys
+from pathlib import Path
+
+DATE_RE = re.compile(r"^#+\s*(\d{4}-\d{2}-\d{2})")
+MARKER_RE = re.compile(r"<{7}|={7}|>{7}")
+
+
+def collect_markdown_files(repo: Path) -> list[Path]:
+    """Return all markdown files under repo excluding generated output."""
+    return [
+        p
+        for p in repo.rglob("*.md")
+        if "generated" not in p.parts and "openapi" not in p.parts
+    ]
+
+
+def check_notes_order(notes_path: Path) -> bool:
+    """Ensure NOTES.md headings are chronological."""
+    try:
+        lines = notes_path.read_text().splitlines()
+    except Exception as exc:  # defensive coding
+        print(f"error: {exc}", file=sys.stderr)
+        return False
+    dates = [m.group(1) for m in (DATE_RE.match(line) for line in lines) if m]
+    if len(dates) < 2:
+        return True
+    if dates[-1] < dates[-2]:
+        print(
+            f"error: {notes_path} not chronological: {dates[-1]} < {dates[-2]}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def check_markdown(files: list[Path]) -> bool:
+    """Check each file for trailing spaces and conflict markers."""
+    ok = True
+    for path in files:
+        try:
+            lines = path.read_text().splitlines()
+        except Exception as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            ok = False
+            continue
+        for idx, line in enumerate(lines, 1):
+            if line.rstrip() != line:
+                print(f"{path}:{idx}: trailing spaces", file=sys.stderr)
+                ok = False
+            if MARKER_RE.search(line):
+                print(f"{path}:{idx}: conflict marker", file=sys.stderr)
+                ok = False
+    return ok
+
+
+def lint_notes(repo: Path) -> int:
+    """Run all lint checks."""
+    notes_file = repo / "NOTES.md"
+    files = collect_markdown_files(repo)
+    ok = check_notes_order(notes_file)
+    ok &= check_markdown(files)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(__file__).resolve().parents[1]
+    sys.exit(lint_notes(root))

--- a/tests/test_lint_notes.py
+++ b/tests/test_lint_notes.py
@@ -1,0 +1,36 @@
+import sys
+import subprocess
+from pathlib import Path
+
+
+def run_script(tmp_path: Path) -> subprocess.CompletedProcess:
+    script = Path(__file__).resolve().parents[1] / "scripts" / "lint_notes.py"
+    return subprocess.run([sys.executable, str(script), str(tmp_path)])
+
+
+def test_lint_notes_ok(tmp_path):
+    notes = (
+        "## 2024-01-01 PR #1\n\n- entry\n\n"
+        "## 2024-01-02 PR #2\n\n- entry\n"
+    )
+    (tmp_path / "NOTES.md").write_text(notes)
+    (tmp_path / "README.md").write_text("# Title\n")
+    result = run_script(tmp_path)
+    assert result.returncode == 0
+
+
+def test_lint_notes_bad_order(tmp_path):
+    notes = (
+        "## 2024-01-02 PR #1\n\n- entry\n\n"
+        "## 2024-01-01 PR #2\n\n- entry\n"
+    )
+    (tmp_path / "NOTES.md").write_text(notes)
+    result = run_script(tmp_path)
+    assert result.returncode == 1
+
+
+def test_lint_notes_trailing(tmp_path):
+    notes = "## 2024-01-01 PR #1 \n"
+    (tmp_path / "NOTES.md").write_text(notes)
+    result = run_script(tmp_path)
+    assert result.returncode == 1


### PR DESCRIPTION
## Summary
- add `lint_notes.py` script for NOTES ordering, trailing spaces and conflict markers
- integrate lint script into pre-commit and Makefile
- document new lint step in AGENTS guide and tick TODO item
- test lint_notes on good and bad files
- log the work in NOTES

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6875faa30e548325bdd222a2669c20b8