### PR TITLE
Allow specifying WebSocket host

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -35,7 +35,7 @@ python3 -m pip install -r requirements.txt
 python3 -m pip install pre-commit
 
 # install hooks into the shared cache while network is available
-if [ -f .pre-commit-config.yaml ]; then
+if [ -f .pre-commit-config.yaml ] && [ "${SKIP_PRECOMMIT:-0}" != "1" ]; then
   pre-commit install --install-hooks --overwrite
   pre-commit run --all-files
 fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.25 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.26 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -52,6 +52,7 @@ Follow the coding rules described in `CODING_RULES.md`.
 4. On the first PR, update README badges to point at your fork (owner/repo).
 5. `.codex/setup.sh` installs `pre-commit` and sets up the hooks automatically
    on the first run.
+   Set `SKIP_PRECOMMIT=1` to bypass this when offline.
 
 ---
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -660,3 +660,10 @@ automatically and docs updated.
 - **Stage**: implementation
 - **Motivation / Decision**: follow pin policy and automate updates.
 - **Next step**: monitor upcoming dependency PRs.
+
+### 2025-07-15  PR #81
+
+- **Summary**: WebSocket URLs now accept custom host/port with default 8000; README documents example. Setup script can skip pre-commit.
+- **Stage**: implementation
+- **Motivation / Decision**: allow connecting to remote backends and avoid setup failures in offline environments.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ python -m http.server --directory frontend/dist 8080
 
 Then open [http://localhost:8080/](http://localhost:8080/) <!-- lychee skip -->
 in your browser.
+The page connects to `ws://localhost:8000/pose` by default.
 
 ## Backend
 

--- a/TODO.md
+++ b/TODO.md
@@ -93,3 +93,6 @@
 - [x] Quote `$GITHUB_OUTPUT` in secret-check step of CI workflow.
 - [x] Setup script installs `pre-commit` automatically.
 - [x] Setup script installs pre-commit hooks and runs them once.
+- [x] Allow customizing WebSocket host and port; default 8000 in `resolveUrl`.
+- [x] Add SKIP_PRECOMMIT option in setup script to skip hook installation when offline.
+

--- a/frontend/src/__tests__/useWebSocket.test.tsx
+++ b/frontend/src/__tests__/useWebSocket.test.tsx
@@ -1,0 +1,10 @@
+import { resolveUrl } from '../hooks/useWebSocket';
+
+test('defaults to port 8000 when no protocol is given', () => {
+  Object.defineProperty(window, 'location', {
+    value: { protocol: 'http:', hostname: 'example.com', host: 'example.com' },
+    writable: true,
+  });
+  expect(resolveUrl('/pose')).toBe('ws://example.com:8000/pose');
+});
+

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,18 +1,26 @@
 import { useEffect, useRef, useState } from 'react';
 
-function resolveUrl(path: string): string {
+export function resolveUrl(
+  path: string,
+  host: string = window.location.hostname,
+  port = 8000,
+): string {
   if (path.startsWith('ws')) return path;
-  const loc = window.location;
-  const protocol = loc.protocol === 'https:' ? 'wss' : 'ws';
-  return `${protocol}://${loc.host}${path}`;
+  const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+  const addr = host.includes(':') ? host : `${host}:${port}`;
+  return `${protocol}://${addr}${path}`;
 }
 
-export default function useWebSocket<T>(path: string) {
+export default function useWebSocket<T>(
+  path: string,
+  host?: string,
+  port = 8000,
+) {
   const [poseData, setPoseData] = useState<T | null>(null);
   const wsRef = useRef<WebSocket>();
 
   useEffect(() => {
-    const url = resolveUrl(path);
+    const url = resolveUrl(path, host, port);
     const ws = new WebSocket(url);
     ws.onmessage = (ev) => {
       try {
@@ -26,7 +34,7 @@ export default function useWebSocket<T>(path: string) {
     return () => {
       ws.close();
     };
-  }, [path]);
+  }, [path, host, port]);
 
   return { poseData };
 }


### PR DESCRIPTION
## Summary
- allow resolving WebSocket URLs with custom host/port
- let setup script skip pre-commit via `SKIP_PRECOMMIT`
- describe default ws URL in README
- add Jest test for resolveUrl default port
- note completed tasks

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687600fd2bbc8325ad716d98fbbca6fe