### PR TITLE
docs: mark frontend index task done

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -683,3 +683,10 @@ PoseViewer easily.
 - **Stage**: maintenance
 - **Motivation / Decision**: keep roadmap concise and avoid repetition.
 - **Next step**: none.
+
+### 2025-07-15  PR #84
+
+- **Summary**: marked TODO for index.tsx entrypoint as done and refreshed date.
+- **Stage**: documentation
+- **Motivation / Decision**: keep roadmap in sync with completed work.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -93,4 +93,4 @@
 - [x] Setup script installs pre-commit hooks and runs them once.
 - [x] Allow customizing WebSocket host and port; default 8000 in `resolveUrl`.
 - [x] Add SKIP_PRECOMMIT option in setup script to skip hook installation when offline.
-- [ ] Add index.tsx entrypoint and bundler script for frontend.
+- [x] Add index.tsx entrypoint and bundler script for frontend.


### PR DESCRIPTION
## Summary
- tick TODO for index.tsx entrypoint and bundler script
- update NOTES with the change
- refresh roadmap header

## Testing
- `make lint-docs`

------
https://chatgpt.com/codex/tasks/task_e_68760deec1c8832595ff5b62e8a42e31