### PR TITLE
Fix CI precommit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Bootstrap
-        run: ./.codex/setup.sh
+        run: SKIP_PRECOMMIT=1 ./.codex/setup.sh
       - name: Install Python deps
         run: python -m pip install -r requirements.txt
       - run: make lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.27 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.28 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -43,6 +43,7 @@ document information in code files.
 ---
 
 ## Shared environment
+
 shell: |
   export PRE_COMMIT_HOME="$WORKSPACE/.pre-commit-cache"
 
@@ -59,7 +60,8 @@ shell: |
 4. On the first PR, update README badges to point at your fork (owner/repo).
 5. `.codex/setup.sh` installs `pre-commit` and sets up the hooks automatically
    on the first run.
-   Set `SKIP_PRECOMMIT=1` to bypass this when offline.
+   Set `SKIP_PRECOMMIT=1` to bypass this when offline. The CI workflow passes
+   this flag because the runners have restricted network access.
 
 ---
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -699,3 +699,12 @@ in `.pre-commit-cache`
 - **Stage**: documentation
 - **Motivation / Decision**: keep roadmap in sync with completed work.
 - **Next step**: none.
+
+### 2025-07-15  PR #86
+
+- **Summary**: CI now skips pre-commit hook installation using `SKIP_PRECOMMIT=1`;
+  fixed AGENTS markdown formatting.
+- **Stage**: maintenance
+- **Motivation / Decision**: pre-commit fetch failed in CI without network;
+  add note in guide and update workflow.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -95,3 +95,4 @@
 - [x] Add SKIP_PRECOMMIT option in setup script to skip hook installation when offline.
 - [x] Store pre-commit hooks in `.pre-commit-cache` for offline reuse.
 - [x] Add index.tsx entrypoint and bundler script for frontend.
+- [x] Configure CI to pass `SKIP_PRECOMMIT=1` when running setup.


### PR DESCRIPTION
## Summary
- skip hook installation during CI by setting `SKIP_PRECOMMIT=1`
- clarify the flag in AGENTS
- fix markdownlint complaint in AGENTS
- document the CI change in TODO and NOTES

## Testing
- `npx --yes markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_687610f5c4b48325a59a337d531200d9