### PR TITLE
Remove ts-jest globals warning

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -708,3 +708,12 @@ in `.pre-commit-cache`
 - **Motivation / Decision**: pre-commit fetch failed in CI without network;
   add note in guide and update workflow.
 - **Next step**: none.
+
+### 2025-07-15  PR #87
+
+- **Summary**: replaced deprecated `globals` config in `jest.config.js` with a
+  `transform` entry and reran tests.
+- **Stage**: maintenance
+- **Motivation / Decision**: remove ts-jest deprecation warning during
+  `npm test`.
+- **Next step**: none.

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   roots: ['<rootDir>/frontend/src'],
   moduleFileExtensions: ['ts', 'tsx', 'js'],
   testMatch: ['**/__tests__/**/*.test.tsx'],
-  globals: {
-    'ts-jest': { tsconfig: 'frontend/tsconfig.json' }
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'frontend/tsconfig.json' }]
   },
 };


### PR DESCRIPTION
## Summary
- update jest config to use `transform` instead of deprecated `globals`
- document the change in NOTES

## Testing
- `make lint`
- `make test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68761c2bcb3c8325aca7b011baedd77a