### PR TITLE
Implement FastAPI lifespan cleanup

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -708,3 +708,12 @@ in `.pre-commit-cache`
 - **Motivation / Decision**: pre-commit fetch failed in CI without network;
   add note in guide and update workflow.
 - **Next step**: none.
+
+### 2025-07-15  PR #87
+
+- **Summary**: FastAPI app now uses lifespan to release video capture and tests
+  close the fake device.
+- **Stage**: implementation
+- **Motivation / Decision**: replace deprecated shutdown event and avoid
+  warnings during tests.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -96,3 +96,4 @@
 - [x] Store pre-commit hooks in `.pre-commit-cache` for offline reuse.
 - [x] Add index.tsx entrypoint and bundler script for frontend.
 - [x] Configure CI to pass `SKIP_PRECOMMIT=1` when running setup.
+- [x] Release video capture with FastAPI lifespan context.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,16 +1,20 @@
 from fastapi import FastAPI, WebSocket
 import cv2
+from contextlib import asynccontextmanager
 
 from .pose_detector import PoseDetector
 
-app = FastAPI()
-_detector = PoseDetector()
 _capture = cv2.VideoCapture(0)
+_detector = PoseDetector()
 
 
-@app.on_event("shutdown")
-def _cleanup() -> None:
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    yield
     _capture.release()
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 @app.websocket("/pose")

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   roots: ['<rootDir>/frontend/src'],
   moduleFileExtensions: ['ts', 'tsx', 'js'],
   testMatch: ['**/__tests__/**/*.test.tsx'],
-  globals: {
-    'ts-jest': { tsconfig: 'frontend/tsconfig.json' }
+  transform: {
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: 'frontend/tsconfig.json' }]
   },
 };

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore:.*PyType_Spec.*:DeprecationWarning


### PR DESCRIPTION
## Summary
- manage shutdown with async lifespan in `backend/main.py`
- ensure `_capture` closes in tests using lifespan
- remove deprecated ts-jest globals config
- filter google protobuf deprecation warnings in pytest
- record changes in roadmap and notes

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68761c1f035483259821ae50884d555d