### PR TITLE
Add black formatting check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.28 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.29 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -88,7 +88,8 @@ shell: |
       verify pinned versions exist. CI runs this automatically when
       `requirements.txt`, `package.json` or `package-lock.json` change.
     - Run `make docs` to build the HTML docs into `docs/_build`.
-    - Python code under `scripts/` and `tests/` is linted with `ruff` via `make lint`.
+    - Python code in `backend/`, `scripts/` and `tests/` is formatted with `black`
+      and linted with `ruff` via `make lint`.
     - GitHub Actions workflows are linted with
       `actionlint` pinned at v1.7.7 via pre-commit.
     - `make test` expects dependencies from `.codex/setup.sh`.

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 lint:
 	npx --yes markdownlint-cli **/*.md
+	black --check backend scripts tests
 	ruff check scripts tests
 
 lint-docs: lint

--- a/NOTES.md
+++ b/NOTES.md
@@ -730,3 +730,10 @@ with `.gitkeep` to remove Sphinx warning.
 - **Motivation / Decision**: remove ts-jest deprecation warning during
   `npm test`.
 - **Next step**: none.
+
+### 2025-07-15  PR #90
+
+- **Summary**: added black to lint step and formatted Python files.
+- **Stage**: implementation
+- **Motivation / Decision**: enforce consistent style using black in CI; updated docs.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -97,3 +97,4 @@
 - [x] Add index.tsx entrypoint and bundler script for frontend.
 - [x] Configure CI to pass `SKIP_PRECOMMIT=1` when running setup.
 - [x] Remove deprecated backend main entrypoint and tests.
+- [x] Run black formatting via Makefile lint

--- a/backend/analytics.py
+++ b/backend/analytics.py
@@ -8,8 +8,8 @@ Point = Mapping[str, float]
 
 
 def _validate_point(pt: Point) -> None:
-    if pt is None or 'x' not in pt or 'y' not in pt:
-        raise ValueError('invalid point')
+    if pt is None or "x" not in pt or "y" not in pt:
+        raise ValueError("invalid point")
 
 
 def calculate_angle(a: Point, b: Point, c: Point) -> float:
@@ -33,17 +33,17 @@ def calculate_angle(a: Point, b: Point, c: Point) -> float:
     _validate_point(a)
     _validate_point(b)
     _validate_point(c)
-    abx = a['x'] - b['x']
-    aby = a['y'] - b['y']
-    cbx = c['x'] - b['x']
-    cby = c['y'] - b['y']
+    abx = a["x"] - b["x"]
+    aby = a["y"] - b["y"]
+    cbx = c["x"] - b["x"]
+    cby = c["y"] - b["y"]
     dot = abx * cbx + aby * cby
-    mag_ab = sqrt(abx ** 2 + aby ** 2)
-    mag_cb = sqrt(cbx ** 2 + cby ** 2)
+    mag_ab = sqrt(abx**2 + aby**2)
+    mag_cb = sqrt(cbx**2 + cby**2)
     if mag_ab == 0 or mag_cb == 0:
-        raise ValueError('zero-length vector')
+        raise ValueError("zero-length vector")
     cos_angle = max(min(dot / (mag_ab * mag_cb), 1.0), -1.0)
-    return degrees(atan2(sqrt(1 - cos_angle ** 2), cos_angle))
+    return degrees(atan2(sqrt(1 - cos_angle**2), cos_angle))
 
 
 def balance_score(landmarks: Mapping[str, Point]) -> float:
@@ -64,18 +64,18 @@ def balance_score(landmarks: Mapping[str, Point]) -> float:
     ValueError
         If required landmarks are missing.
     """
-    left = landmarks.get('left_hip')
-    right = landmarks.get('right_hip')
+    left = landmarks.get("left_hip")
+    right = landmarks.get("right_hip")
     _validate_point(left)
     _validate_point(right)
-    return abs(left['x'] - right['x'])
+    return abs(left["x"] - right["x"])
 
 
 def pose_classification(landmarks: Mapping[str, Point]) -> str:
     """Return 'standing', 'sitting' or 'unknown'."""
-    hip_angle = float('nan')
-    knee_angle = float('nan')
-    for side in ('left', 'right'):
+    hip_angle = float("nan")
+    knee_angle = float("nan")
+    for side in ("left", "right"):
         try:
             hip_angle = calculate_angle(
                 landmarks[f"{side}_shoulder"],
@@ -91,14 +91,14 @@ def pose_classification(landmarks: Mapping[str, Point]) -> str:
         except KeyError:
             continue
         except ValueError:
-            hip_angle = float('nan')
-            knee_angle = float('nan')
+            hip_angle = float("nan")
+            knee_angle = float("nan")
             break
     if hip_angle != hip_angle or knee_angle != knee_angle:
-        return 'unknown'
+        return "unknown"
     if hip_angle > 150 and knee_angle > 150:
-        return 'standing'
-    return 'sitting'
+        return "standing"
+    return "sitting"
 
 
 def extract_pose_metrics(landmarks: Mapping[str, Point]) -> Dict[str, float]:
@@ -120,6 +120,6 @@ def extract_pose_metrics(landmarks: Mapping[str, Point]) -> Dict[str, float]:
     try:
         balance = balance_score(landmarks)
     except ValueError:
-        balance = float('nan')
+        balance = float("nan")
     pose = pose_classification(landmarks)
-    return {'knee_angle': knee_angle, 'balance': balance, 'pose_class': pose}
+    return {"knee_angle": knee_angle, "balance": balance, "pose_class": pose}

--- a/backend/pose_detector.py
+++ b/backend/pose_detector.py
@@ -12,16 +12,18 @@ class PoseDetector:
     def process(self, frame: np.ndarray) -> list[dict[str, float]]:
         """Return 17 keypoints as dicts with x, y and visibility."""
         if frame is None:
-            raise ValueError('frame is None')
+            raise ValueError("frame is None")
         rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         results = self._pose.process(rgb)
         if not results.pose_landmarks:
             return []
         keypoints = []
         for lm in results.pose_landmarks.landmark[:17]:
-            keypoints.append({
-                'x': float(lm.x),
-                'y': float(lm.y),
-                'visibility': float(lm.visibility),
-            })
+            keypoints.append(
+                {
+                    "x": float(lm.x),
+                    "y": float(lm.y),
+                    "visibility": float(lm.visibility),
+                }
+            )
         return keypoints

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -86,5 +86,7 @@ def check_versions(repo_dir: Path) -> int:
 
 
 if __name__ == "__main__":
-    root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(__file__).resolve().parents[1]
+    root = (
+        Path(sys.argv[1]) if len(sys.argv) > 1 else Path(__file__).resolve().parents[1]
+    )
     sys.exit(check_versions(root))

--- a/scripts/update_todo_date.py
+++ b/scripts/update_todo_date.py
@@ -55,5 +55,9 @@ def update_todo_date(todo_path: Path) -> int:
 
 
 if __name__ == "__main__":
-    path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(__file__).resolve().parents[1] / "TODO.md"
+    path = (
+        Path(sys.argv[1])
+        if len(sys.argv) > 1
+        else Path(__file__).resolve().parents[1] / "TODO.md"
+    )
     sys.exit(update_todo_date(path))

--- a/tests/backend/test_pose_detector.py
+++ b/tests/backend/test_pose_detector.py
@@ -10,7 +10,9 @@ class FakePose:
 
     def process(self, frame):
         lm = types.SimpleNamespace(x=1.0, y=2.0, visibility=0.5)
-        return types.SimpleNamespace(pose_landmarks=types.SimpleNamespace(landmark=[lm] * 33))
+        return types.SimpleNamespace(
+            pose_landmarks=types.SimpleNamespace(landmark=[lm] * 33)
+        )
 
 
 def test_process_success(monkeypatch):

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -10,17 +10,17 @@ from backend.analytics import (
 
 
 def test_calculate_angle_basic():
-    a = {'x': 0.0, 'y': 0.0}
-    b = {'x': 1.0, 'y': 0.0}
-    c = {'x': 1.0, 'y': 1.0}
+    a = {"x": 0.0, "y": 0.0}
+    b = {"x": 1.0, "y": 0.0}
+    c = {"x": 1.0, "y": 1.0}
     angle = calculate_angle(a, b, c)
     assert math.isclose(angle, 90.0, abs_tol=1e-2)
 
 
 def test_calculate_angle_invalid():
-    a = {'x': 0.0}
+    a = {"x": 0.0}
     with pytest.raises(ValueError):
-        calculate_angle(a, {'x': 0.0, 'y': 0.0}, {'x': 1.0, 'y': 0.0})
+        calculate_angle(a, {"x": 0.0, "y": 0.0}, {"x": 1.0, "y": 0.0})
 
 
 def test_balance_score_missing():
@@ -30,44 +30,44 @@ def test_balance_score_missing():
 
 def test_extract_pose_metrics_missing_landmarks():
     metrics = extract_pose_metrics({})
-    assert math.isnan(metrics['knee_angle'])
-    assert math.isnan(metrics['balance'])
-    assert metrics['pose_class'] == 'unknown'
+    assert math.isnan(metrics["knee_angle"])
+    assert math.isnan(metrics["balance"])
+    assert metrics["pose_class"] == "unknown"
 
 
 def test_extract_pose_metrics_left_side():
     lms = {
-        'left_hip': {'x': 0.0, 'y': 0.0},
-        'left_knee': {'x': 0.0, 'y': 1.0},
-        'left_ankle': {'x': 1.0, 'y': 1.0},
-        'right_hip': {'x': 1.0, 'y': 0.0},
+        "left_hip": {"x": 0.0, "y": 0.0},
+        "left_knee": {"x": 0.0, "y": 1.0},
+        "left_ankle": {"x": 1.0, "y": 1.0},
+        "right_hip": {"x": 1.0, "y": 0.0},
     }
     metrics = extract_pose_metrics(lms)
-    assert not math.isnan(metrics['knee_angle'])
-    assert not math.isnan(metrics['balance'])
-    assert metrics['pose_class'] in {'standing', 'sitting', 'unknown'}
+    assert not math.isnan(metrics["knee_angle"])
+    assert not math.isnan(metrics["balance"])
+    assert metrics["pose_class"] in {"standing", "sitting", "unknown"}
 
 
 def test_extract_pose_metrics_right_side():
     lms = {
-        'right_hip': {'x': 1.0, 'y': 0.0},
-        'right_knee': {'x': 1.0, 'y': 1.0},
-        'right_ankle': {'x': 0.0, 'y': 1.0},
-        'left_hip': {'x': 0.0, 'y': 0.0},
+        "right_hip": {"x": 1.0, "y": 0.0},
+        "right_knee": {"x": 1.0, "y": 1.0},
+        "right_ankle": {"x": 0.0, "y": 1.0},
+        "left_hip": {"x": 0.0, "y": 0.0},
     }
     metrics = extract_pose_metrics(lms)
-    assert not math.isnan(metrics['knee_angle'])
-    assert not math.isnan(metrics['balance'])
-    assert metrics['pose_class'] in {'standing', 'sitting', 'unknown'}
+    assert not math.isnan(metrics["knee_angle"])
+    assert not math.isnan(metrics["balance"])
+    assert metrics["pose_class"] in {"standing", "sitting", "unknown"}
 
 
 def test_pose_classification():
     lms = {
-        'left_shoulder': {'x': 0.0, 'y': 0.0},
-        'left_hip': {'x': 0.0, 'y': 1.0},
-        'left_knee': {'x': 0.0, 'y': 2.0},
-        'left_ankle': {'x': 0.0, 'y': 3.0},
+        "left_shoulder": {"x": 0.0, "y": 0.0},
+        "left_hip": {"x": 0.0, "y": 1.0},
+        "left_knee": {"x": 0.0, "y": 2.0},
+        "left_ankle": {"x": 0.0, "y": 3.0},
     }
-    assert pose_classification(lms) == 'standing'
-    lms['left_knee']['x'] = 1.0
-    assert pose_classification(lms) == 'sitting'
+    assert pose_classification(lms) == "standing"
+    lms["left_knee"]["x"] = 1.0
+    assert pose_classification(lms) == "sitting"

--- a/tests/test_check_versions.py
+++ b/tests/test_check_versions.py
@@ -6,10 +6,13 @@ import scripts.check_versions as cv
 def fake_urlopen_success(url):
     class Resp:
         status = 200
+
         def __enter__(self):
             return self
+
         def __exit__(self, exc_type, exc, tb):
             pass
+
     return Resp()
 
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -19,6 +19,7 @@ def test_generate_script_unwritable(tmp_path, monkeypatch):
     scripts_dir = repo_root / "scripts"
     scripts_dir.mkdir()
     from scripts import generate
+
     monkeypatch.setattr(generate, "__file__", str(scripts_dir / "generate.py"))
 
     gen_dir = repo_root / "generated"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,22 +6,22 @@ import time
 
 def test_build_payload_format():
     lms = {
-        'hip': {'x': 0.1, 'y': 0.2},
-        'knee': {'x': 0.3, 'y': 0.4},
-        'ankle': {'x': 0.5, 'y': 0.6},
-        'left_hip': {'x': 0.1, 'y': 0.2},
-        'right_hip': {'x': 0.2, 'y': 0.2},
+        "hip": {"x": 0.1, "y": 0.2},
+        "knee": {"x": 0.3, "y": 0.4},
+        "ankle": {"x": 0.5, "y": 0.6},
+        "left_hip": {"x": 0.1, "y": 0.2},
+        "right_hip": {"x": 0.2, "y": 0.2},
     }
     payload = build_payload(lms)
-    assert isinstance(payload['landmarks'], list)
-    assert payload['landmarks'][0] == {'x': 0.1, 'y': 0.2}
-    metrics = payload['metrics']
-    assert {'knee_angle', 'balance', 'pose_class'} <= metrics.keys()
+    assert isinstance(payload["landmarks"], list)
+    assert payload["landmarks"][0] == {"x": 0.1, "y": 0.2}
+    metrics = payload["metrics"]
+    assert {"knee_angle", "balance", "pose_class"} <= metrics.keys()
 
 
 def test_server_starts():
     proc = subprocess.Popen(
-        [sys.executable, '-m', 'backend.server'],
+        [sys.executable, "-m", "backend.server"],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )

--- a/tests/test_update_todo_date.py
+++ b/tests/test_update_todo_date.py
@@ -5,11 +5,7 @@ import subprocess
 
 
 def test_update_todo_date(tmp_path):
-    sample = (
-        "# TODO – Road‑map (last updated: 2000-01-01)\n"
-        "\n"
-        "rest\n"
-    )
+    sample = "# TODO – Road‑map (last updated: 2000-01-01)\n" "\n" "rest\n"
     todo_file = tmp_path / "TODO.md"
     todo_file.write_text(sample)
 


### PR DESCRIPTION
## Summary
- run black check in the `lint` target
- format python sources with black
- document new lint command in AGENTS guide
- log update in NOTES and mark roadmap item

## Testing
- `make lint`
- `make lint-docs`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6876235bcfd083259e36cc36272da6f1