### PR TITLE
Add mypy type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,4 +75,5 @@ jobs:
       - name: Install Python deps
         run: python -m pip install -r requirements.txt
       - run: make lint
+      - run: make typecheck
       - run: make test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.28 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.29 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -74,6 +74,7 @@ shell: |
 
    ```bash
    make lint                  # all format / static‑analysis steps
+   make typecheck             # mypy static type checking
    make test                  # unit/integration tests with coverage ≥80%
    pre-commit run --files <changed>
    ```
@@ -89,6 +90,7 @@ shell: |
       `requirements.txt`, `package.json` or `package-lock.json` change.
     - Run `make docs` to build the HTML docs into `docs/_build`.
     - Python code under `scripts/` and `tests/` is linted with `ruff` via `make lint`.
+    - Static type checking uses mypy via `make typecheck`.
     - GitHub Actions workflows are linted with
       `actionlint` pinned at v1.7.7 via pre-commit.
     - `make test` expects dependencies from `.codex/setup.sh`.
@@ -182,6 +184,7 @@ jobs:
       - name: Bootstrap
         run: ./.codex/setup.sh   # idempotent; safe when absent
       - run: make lint
+      - run: make typecheck
       - run: make test
 ```
 <!-- markdownlint-enable MD013 -->

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint lint-docs test generate docs
+.PHONY: lint lint-docs test generate docs typecheck
 
 lint:
 	npx --yes markdownlint-cli **/*.md
@@ -16,8 +16,13 @@ test:
 	npx --yes jest; \
 	fi
 
+
 generate:
 	python scripts/generate.py
+
+
+typecheck:
+	mypy backend
 
 update-todo-date:
 	python scripts/update_todo_date.py

--- a/NOTES.md
+++ b/NOTES.md
@@ -730,3 +730,10 @@ with `.gitkeep` to remove Sphinx warning.
 - **Motivation / Decision**: remove ts-jest deprecation warning during
   `npm test`.
 - **Next step**: none.
+
+### 2025-07-15  PR #90
+
+- **Summary**: added mypy type-checking step and improved analytics typing.
+- **Stage**: implementation
+- **Motivation / Decision**: enforce rule 16 via CI type checks.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -97,3 +97,5 @@
 - [x] Add index.tsx entrypoint and bundler script for frontend.
 - [x] Configure CI to pass `SKIP_PRECOMMIT=1` when running setup.
 - [x] Remove deprecated backend main entrypoint and tests.
+
+- [x] Integrate mypy type checking with Makefile target and CI.

--- a/backend/analytics.py
+++ b/backend/analytics.py
@@ -7,7 +7,7 @@ from typing import Dict, Mapping
 Point = Mapping[str, float]
 
 
-def _validate_point(pt: Point) -> None:
+def _validate_point(pt: Mapping[str, float] | None) -> None:
     if pt is None or 'x' not in pt or 'y' not in pt:
         raise ValueError('invalid point')
 
@@ -68,6 +68,7 @@ def balance_score(landmarks: Mapping[str, Point]) -> float:
     right = landmarks.get('right_hip')
     _validate_point(left)
     _validate_point(right)
+    assert left is not None and right is not None
     return abs(left['x'] - right['x'])
 
 
@@ -101,7 +102,7 @@ def pose_classification(landmarks: Mapping[str, Point]) -> str:
     return 'sitting'
 
 
-def extract_pose_metrics(landmarks: Mapping[str, Point]) -> Dict[str, float]:
+def extract_pose_metrics(landmarks: Mapping[str, Point]) -> Dict[str, float | str]:
     """Return analytics dictionary from pose landmarks."""
     knee_angle = float("nan")
     for side in ("left", "right"):

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True


### PR DESCRIPTION
## Summary
- configure mypy with ignore_missing_imports
- allow optional points in analytics and update return types
- add `make typecheck` and integrate in CI
- document new workflow and note progress

## Testing
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6876235917ec832595f61be2b4f82acc