### PR TITLE
Pin numpy for compatibility

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -743,3 +743,10 @@ with `.gitkeep` to remove Sphinx warning.
 - **Stage**: implementation
 - **Motivation / Decision**: enforce consistent style using black in CI; updated docs.
 - **Next step**: none.
+
+### 2025-07-15  PR #92
+
+- **Summary**: pinned numpy 1.26.4 and updated README quick start.
+- **Stage**: maintenance
+- **Motivation / Decision**: keep dependencies compatible; check-versions passes.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ make lint
 make test
 ```
 
-The Python dependencies install `mediapipe==0.10.13` and
-`websockets==15.0.1`. Mediapipe 0.10.13 supports `numpy>=2`.
+The Python dependencies install `mediapipe==0.10.13`,
+`websockets==15.0.1` and `numpy==1.26.4`.
 
 ### Backend server
 

--- a/backend/analytics.py
+++ b/backend/analytics.py
@@ -8,10 +8,10 @@ Point = Mapping[str, float]
 
 
 def _validate_point(pt: Mapping[str, float] | None) -> None:
-    if pt is None or 'x' not in pt or 'y' not in pt:
-        raise ValueError('invalid point')
+    if pt is None or "x" not in pt or "y" not in pt:
+        raise ValueError("invalid point")
 
-        
+
 def calculate_angle(a: Point, b: Point, c: Point) -> float:
     """Return the angle ABC in degrees.
 
@@ -70,7 +70,7 @@ def balance_score(landmarks: Mapping[str, Point]) -> float:
     _validate_point(right)
 
     assert left is not None and right is not None
-    return abs(left['x'] - right['x'])
+    return abs(left["x"] - right["x"])
 
 
 def pose_classification(landmarks: Mapping[str, Point]) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 fastapi==0.116.1
 uvicorn[standard]==0.35.0
-opencv-python==4.12.0.88
+opencv-python==4.10.0.82
 mediapipe==0.10.13
 ruff==0.4.4
 websockets==15.0.1
 httpx==0.27.0
 pytest-cov==6.2.1
 sphinx==7.2.6
+numpy==1.26.4


### PR DESCRIPTION
## Summary
- pin `numpy==1.26.4`
- downgrade OpenCV requirement to match numpy
- document new dependency in README
- reformat analytics module
- note the change in NOTES

## Testing
- `make check-versions`
- `make lint`
- `make lint-docs`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68762795dcc48325a6af3135260342ed