### PR TITLE
Ignore linter caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ docs/_build/
 frontend/dist/bundle.js
 frontend/dist/bundle.js.map
 .pre-commit-cache/
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/

--- a/NOTES.md
+++ b/NOTES.md
@@ -743,3 +743,10 @@ with `.gitkeep` to remove Sphinx warning.
 - **Stage**: implementation
 - **Motivation / Decision**: enforce consistent style using black in CI; updated docs.
 - **Next step**: none.
+
+### 2025-07-15  PR #92
+
+- **Summary**: ignored mypy, pytest and ruff caches in `.gitignore`.
+- **Stage**: maintenance
+- **Motivation / Decision**: keep temporary caches out of version control.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -99,3 +99,4 @@
 - [x] Remove deprecated backend main entrypoint and tests.
 - [x] Integrate mypy type checking with Makefile target and CI.
 - [x] Run black formatting via Makefile lint
+- [x] Ignore mypy, pytest and ruff caches in .gitignore.

--- a/backend/analytics.py
+++ b/backend/analytics.py
@@ -8,10 +8,10 @@ Point = Mapping[str, float]
 
 
 def _validate_point(pt: Mapping[str, float] | None) -> None:
-    if pt is None or 'x' not in pt or 'y' not in pt:
-        raise ValueError('invalid point')
+    if pt is None or "x" not in pt or "y" not in pt:
+        raise ValueError("invalid point")
 
-        
+
 def calculate_angle(a: Point, b: Point, c: Point) -> float:
     """Return the angle ABC in degrees.
 
@@ -70,7 +70,7 @@ def balance_score(landmarks: Mapping[str, Point]) -> float:
     _validate_point(right)
 
     assert left is not None and right is not None
-    return abs(left['x'] - right['x'])
+    return abs(left["x"] - right["x"])
 
 
 def pose_classification(landmarks: Mapping[str, Point]) -> str:


### PR DESCRIPTION
## Summary
- keep mypy, pytest and ruff caches out of version control
- update roadmap
- record the change in `NOTES.md`
- format analytics module so lint passes

## Testing
- `make lint`
- `make lint-docs`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687627a43bd48325830a000adcfd4058