### PR TITLE
Update PRE_COMMIT_HOME logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.29 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.30 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -46,7 +46,11 @@ document information in code files.
 ## Shared environment
 
 shell: |
-  export PRE_COMMIT_HOME="$WORKSPACE/.pre-commit-cache"
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+  export PRE_COMMIT_HOME="${PRE_COMMIT_HOME:-$REPO_ROOT/.pre-commit-cache}"
+
+Running `.codex/setup.sh` downloads hooks into this directory and
+prevents GitHub prompts.
 
 ## 2 · Bootstrap (first-run) checklist
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -781,3 +781,10 @@ updated docs.
 - **Motivation / Decision**: align package.json
 style with other entries and keep lock file in sync.
 - **Next step**: none.
+
+### 2025-07-15  PR #97
+
+- **Summary**: AGENTS guide sets PRE_COMMIT_HOME using git rev-parse and explains hook cache.
+- **Stage**: documentation
+- **Motivation / Decision**: ensure pre-commit cache works in subdirectories and avoid GitHub prompts after running setup.
+- **Next step**: none.


### PR DESCRIPTION
## Summary
- compute `PRE_COMMIT_HOME` relative to git repo root
- document that `.codex/setup.sh` installs hooks into this cache
- log update in NOTES

## Testing
- `make lint-docs`

------
https://chatgpt.com/codex/tasks/task_e_68762d43d6448325970675f23b6a5b57