### PR TITLE
Update README with offline pre-commit note

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -781,3 +781,11 @@ updated docs.
 - **Motivation / Decision**: align package.json
 style with other entries and keep lock file in sync.
 - **Next step**: none.
+
+### 2025-07-15  PR #97
+
+- **Summary**: README quick-start explains pre-commit setup and offline flag.
+- **Stage**: documentation
+- **Motivation / Decision**: guide contributors on fetching hooks and using
+  `SKIP_PRECOMMIT=1` when network is not available.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -20,10 +20,15 @@ dependencies, then check the code:
 ```bash
 git clone <repo-url>
 cd PoseDetection
+# run once with network access to fetch pre-commit hooks
 .codex/setup.sh
 make lint
 make test
 ```
+
+If the network is unavailable pass `SKIP_PRECOMMIT=1` to the setup script.
+`pre-commit run` will then try to fetch hooks and may ask for GitHub
+credentials.
 
 The Python dependencies install `mediapipe==0.10.13`,
 `websockets==15.0.1` and `numpy==1.26.4`.

--- a/TODO.md
+++ b/TODO.md
@@ -101,3 +101,4 @@
 - [x] Run black formatting via Makefile lint
 - [x] Ignore mypy, pytest and ruff caches in .gitignore.
 - [x] Close MediaPipe pose detector after releasing camera in server.
+- [x] Mention SKIP_PRECOMMIT usage in README quick-start instructions.


### PR DESCRIPTION
## Summary
- clarify how `.codex/setup.sh` fetches pre-commit hooks
- document using `SKIP_PRECOMMIT=1` when offline
- log the change and tick TODO roadmap

## Testing
- `make lint-docs`

------
https://chatgpt.com/codex/tasks/task_e_68762d4d5d248325bdcf71f2227e160f