### PR TITLE
Respect custom pre-commit cache location

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-export PRE_COMMIT_HOME="$PROJECT_ROOT/.pre-commit-cache"
+PRE_COMMIT_HOME="${PRE_COMMIT_HOME:-$PROJECT_ROOT/.pre-commit-cache}"
+export PRE_COMMIT_HOME
 mkdir -p "$PRE_COMMIT_HOME"
 cd "$PROJECT_ROOT"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.29 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.30 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -46,7 +46,7 @@ document information in code files.
 ## Shared environment
 
 shell: |
-  export PRE_COMMIT_HOME="$WORKSPACE/.pre-commit-cache"
+  export PRE_COMMIT_HOME="${PRE_COMMIT_HOME:-$WORKSPACE/.pre-commit-cache}"
 
 ## 2 · Bootstrap (first-run) checklist
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -781,3 +781,10 @@ updated docs.
 - **Motivation / Decision**: align package.json
 style with other entries and keep lock file in sync.
 - **Next step**: none.
+
+### 2025-07-15  PR #97
+
+- **Summary**: setup script uses existing PRE_COMMIT_HOME if provided and guide updated.
+- **Stage**: maintenance
+- **Motivation / Decision**: permit custom pre-commit cache locations without override.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -101,3 +101,4 @@
 - [x] Run black formatting via Makefile lint
 - [x] Ignore mypy, pytest and ruff caches in .gitignore.
 - [x] Close MediaPipe pose detector after releasing camera in server.
+- [x] Setup script respects existing PRE_COMMIT_HOME variable.


### PR DESCRIPTION
## Summary
- allow overriding `PRE_COMMIT_HOME` in setup script
- document the override behaviour
- log the change in `NOTES.md`
- tick roadmap item

## Testing
- `make lint`
- `make typecheck`
- `make test`
- `make lint-docs`
- ❌ `pre-commit run --files .codex/setup.sh AGENTS.md NOTES.md TODO.md` *(failed: Username for 'https://github.com')*

------
https://chatgpt.com/codex/tasks/task_e_68762d4b4710832585824ef8f2edd2cf