### PR TITLE
Cache precommit hooks

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -39,6 +39,7 @@ python3 -m pip install pre-commit
 
 # install hooks into the shared cache while network is available
 if [ -f .pre-commit-config.yaml ] && [ "${SKIP_PRECOMMIT:-0}" != "1" ]; then
+  pre-commit install --install-hooks --overwrite --config=.pre-commit-config.yaml
   pre-commit install --install-hooks --overwrite
   pre-commit run --all-files || true
 fi

--- a/NOTES.md
+++ b/NOTES.md
@@ -801,3 +801,10 @@ style with other entries and keep lock file in sync.
 - **Stage**: documentation
 - **Motivation / Decision**: ensure pre-commit cache works in subdirectories and avoid GitHub prompts after running setup.
 - **Next step**: none.
+
+### 2025-07-15  PR #100
+
+- **Summary**: setup script caches pre-commit hooks with explicit config.
+- **Stage**: maintenance
+- **Motivation / Decision**: ensure hooks are installed before network cut.
+- **Next step**: none.


### PR DESCRIPTION
## Summary
- cache hooks with explicit pre-commit config
- log the change

## Testing
- `make lint`
- `make lint-docs`
- `make typecheck`
- `make test` *(fails: ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876302df728832596f183218ff8005a