### PR TITLE
Emphasise running setup script before tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.30 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.31 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -54,10 +54,10 @@ prevents GitHub prompts.
 
 ## 2 · Bootstrap (first-run) checklist
 
-1. Run `.codex/setup.sh` (or `./setup.sh`) once after cloning &
-   whenever dependencies change.
-   *The script installs language tool‑chains,
-   pins versions, installs dependencies and injects secrets.*
+1. Run `.codex/setup.sh` (or `./setup.sh`) once after cloning & whenever
+   dependencies change. *The script installs Python, Node and all packages
+   needed for tests.* Always complete this step before running any test or
+   build.
 2. Export **required secrets** (`GIT_TOKEN`, `GH_PAGES_TOKEN`, …)
    in the repository/organisation **Secrets** console.
 3. Verify the **secret‑detection helper step** in

--- a/NOTES.md
+++ b/NOTES.md
@@ -810,3 +810,12 @@ in subdirectories and avoid GitHub prompts after running setup.
 - **Stage**: maintenance
 - **Motivation / Decision**: ensure hooks are installed before network cut.
 - **Next step**: none.
+
+### 2025-07-15  PR #101
+
+- **Summary**: README and AGENTS guide emphasise running `./.codex/setup.sh`
+  before tests.
+- **Stage**: documentation
+- **Motivation / Decision**: contributors skipped setup which made
+  `make test` fail, so the docs now highlight this requirement.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ keypoints from a webcam and serves them through a small web app. See
 
 ## Quick start
 
-Clone the repository, run `.codex/setup.sh` to install tooling and
-dependencies, then check the code:
+Clone the repository and **run `./.codex/setup.sh` first** to install
+Python and Node packages before running any tests. Then check the code:
 
 ```bash
 git clone <repo-url>
@@ -53,10 +53,11 @@ Dependabot reviews `requirements.txt`, `package.json` and
 
 ## Setup
 
-Run `.codex/setup.sh` after cloning to install Python 3.11, Node 20 and the
-project dependencies. The script is idempotent and exits 0 when finished.
-Pre-commit hooks are stored in `.pre-commit-cache/` so they can be reused
-offline.
+Run `.codex/setup.sh` after cloning to install Python 3.11, Node 20 and all
+project dependencies. Tests rely on these packages, so always complete this
+step before running `make test`. The script is idempotent and exits 0 when
+finished. Pre-commit hooks are stored in `.pre-commit-cache/` so they can be
+reused offline.
 
 ## Frontend
 

--- a/TODO.md
+++ b/TODO.md
@@ -103,3 +103,4 @@
 - [x] Close MediaPipe pose detector after releasing camera in server.
 - [x] Setup script respects existing PRE_COMMIT_HOME variable.
 - [x] Mention SKIP_PRECOMMIT usage in README quick-start instructions.
+- [ ] Emphasise running `./.codex/setup.sh` before tests in README.


### PR DESCRIPTION
## Summary
- emphasise that `./.codex/setup.sh` installs Python and Node packages before tests
- remind about this requirement in AGENTS guide
- log the docs update in NOTES
- track update in TODO

## Testing
- `make lint-docs`


------
https://chatgpt.com/codex/tasks/task_e_6876368fa95883258b8217dfd96308f3