### PR TITLE
docs: note robustness tasks done

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -834,3 +834,12 @@ by reinitialising the pose detector per connection.
 - **Motivation / Decision**: contributors skipped setup which made
   `make test` fail, so the docs now highlight this requirement.
 - **Next step**: none.
+
+### 2025-07-15
+
+- **Summary**: robustness tests confirm multiple `/pose` connections work
+  reliably and README highlights running `./.codex/setup.sh` before tests.
+- **Stage**: maintenance
+- **Motivation / Decision**: ensure stable WebSocket handling and guide
+  contributors to run setup so tests pass.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -104,5 +104,5 @@
 - [x] Setup script respects existing PRE_COMMIT_HOME variable.
 - [x] Mention SKIP_PRECOMMIT usage in README quick-start instructions.
 - [x] Lint backend with ruff in Makefile.
-- [ ] Add robustness tests for repeated WebSocket connections to /pose.
-- [ ] Emphasise running `./.codex/setup.sh` before tests in README.
+- [x] Add robustness tests for repeated WebSocket connections to /pose.
+- [x] Emphasise running `./.codex/setup.sh` before tests in README.


### PR DESCRIPTION
## Summary
- tick tasks for WebSocket tests and README update
- log new bullet about robustness tests and setup instructions

## Testing
- `make lint-docs`
- `make update-todo-date`


------
https://chatgpt.com/codex/tasks/task_e_68763acb0b388325ae53cf8048befed0