### PR TITLE
Pin pytest for stable CI

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -834,3 +834,10 @@ by reinitialising the pose detector per connection.
 - **Motivation / Decision**: contributors skipped setup which made
   `make test` fail, so the docs now highlight this requirement.
 - **Next step**: none.
+### 2025-07-15  PR #104
+
+- **Summary**: pinned pytest to 8.2.0 to keep tests stable.
+- **Stage**: maintenance
+- **Motivation / Decision**: ensures CI uses known version.
+- **Next step**: none.
+

--- a/TODO.md
+++ b/TODO.md
@@ -105,4 +105,4 @@
 - [x] Mention SKIP_PRECOMMIT usage in README quick-start instructions.
 - [x] Lint backend with ruff in Makefile.
 - [ ] Add robustness tests for repeated WebSocket connections to /pose.
-- [ ] Emphasise running `./.codex/setup.sh` before tests in README.
+- [x] Emphasise running `./.codex/setup.sh` before tests in README.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ ruff==0.4.4
 websockets==15.0.1
 httpx==0.27.0
 pytest-cov==6.2.1
+pytest==8.2.0
 sphinx==7.2.6
 numpy==1.26.4


### PR DESCRIPTION
## Summary
- pin pytest to 8.2.0
- document that pytest was pinned for CI stability
- mark TODO item about setup reminder as done

## Testing
- `make lint-docs`
- `make lint`
- `make typecheck`
- `make test`
- `make check-versions`


------
https://chatgpt.com/codex/tasks/task_e_68763ac8de148325b9f405234c2542ef