### PR TITLE
Map 17 pose landmarks by name

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -874,3 +874,12 @@ by reinitialising the pose detector per connection.
 - **Stage**: implementation
 - **Motivation / Decision**: display full analytics to users per feature request.
 - **Next step**: none.
+
+### 2025-07-17  PR #109
+
+- **Summary**: Pose detector now selects 17 explicit landmarks; edges and tests
+  updated accordingly.
+- **Stage**: implementation
+- **Motivation / Decision**: align keypoint order with tech challenge and expose
+  named mapping across backend and frontend.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ The Python dependencies install `mediapipe==0.10.13`,
 
 Run `python -m backend.server` to launch the FastAPI server. The `/pose`
 WebSocket streams 17 keypoints extracted from each video frame. Each point is
-a dictionary with ``x``, ``y`` and ``visibility``. The payload also includes
+a dictionary with ``x``, ``y`` and ``visibility``. The keypoints are ordered as
+``nose``, ``left_eye``, ``right_eye``, ``left_ear``, ``right_ear``,
+``left_shoulder``, ``right_shoulder``, ``left_elbow``, ``right_elbow``,
+``left_wrist``, ``right_wrist``, ``left_hip``, ``right_hip``, ``left_knee``,
+``right_knee``, ``left_ankle`` and ``right_ankle``. The payload also includes
 simple analytics like knee angle, balance and a ``pose_class`` field
 indicating ``standing`` or ``sitting``.
 

--- a/TODO.md
+++ b/TODO.md
@@ -109,3 +109,4 @@
 - [x] Draw skeleton edges in the PoseViewer canvas overlay.
 - [x] Stream 17 keypoints via PoseDetector and close resources.
 - [x] Display knee angle in MetricsPanel with tests.
+- [x] Use PoseLandmark names for 17 keypoints across backend and frontend.

--- a/backend/pose_detector.py
+++ b/backend/pose_detector.py
@@ -6,6 +6,27 @@ import numpy as np
 class PoseDetector:
     """Extract 17 pose keypoints from a BGR video frame."""
 
+    # Ordered subset of MediaPipe landmarks (COCO layout)
+    LANDMARKS = [
+        mp.solutions.pose.PoseLandmark.NOSE,
+        mp.solutions.pose.PoseLandmark.LEFT_EYE,
+        mp.solutions.pose.PoseLandmark.RIGHT_EYE,
+        mp.solutions.pose.PoseLandmark.LEFT_EAR,
+        mp.solutions.pose.PoseLandmark.RIGHT_EAR,
+        mp.solutions.pose.PoseLandmark.LEFT_SHOULDER,
+        mp.solutions.pose.PoseLandmark.RIGHT_SHOULDER,
+        mp.solutions.pose.PoseLandmark.LEFT_ELBOW,
+        mp.solutions.pose.PoseLandmark.RIGHT_ELBOW,
+        mp.solutions.pose.PoseLandmark.LEFT_WRIST,
+        mp.solutions.pose.PoseLandmark.RIGHT_WRIST,
+        mp.solutions.pose.PoseLandmark.LEFT_HIP,
+        mp.solutions.pose.PoseLandmark.RIGHT_HIP,
+        mp.solutions.pose.PoseLandmark.LEFT_KNEE,
+        mp.solutions.pose.PoseLandmark.RIGHT_KNEE,
+        mp.solutions.pose.PoseLandmark.LEFT_ANKLE,
+        mp.solutions.pose.PoseLandmark.RIGHT_ANKLE,
+    ]
+
     def __init__(self) -> None:
         self._pose = mp.solutions.pose.Pose(model_complexity=1)
 
@@ -18,7 +39,8 @@ class PoseDetector:
         if not results.pose_landmarks:
             return []
         keypoints = []
-        for lm in results.pose_landmarks.landmark[:17]:
+        for lm_index in self.LANDMARKS:
+            lm = results.pose_landmarks.landmark[lm_index.value]
             keypoints.append(
                 {
                     "x": float(lm.x),

--- a/backend/server.py
+++ b/backend/server.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import cv2
-import mediapipe as mp
 from fastapi import FastAPI, WebSocket
 
 from typing import Any, Dict, List
@@ -14,8 +13,8 @@ import uvicorn
 
 app = FastAPI()
 
-# names for the first 17 MediaPipe landmarks
-_NAMES = [lm.name.lower() for lm in list(mp.solutions.pose.PoseLandmark)[:17]]
+# names for the 17-landmark subset used by PoseDetector
+_NAMES = [lm.name.lower() for lm in PoseDetector.LANDMARKS]
 
 
 def _to_named(points: List[Dict[str, float]]) -> Dict[str, Dict[str, float]]:

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,12 @@ full assignment and requirements are listed in
 
 Placeholder for project docs.
 
+The pose detector outputs 17 landmarks in the following order:
+``nose``, ``left_eye``, ``right_eye``, ``left_ear``, ``right_ear``,
+``left_shoulder``, ``right_shoulder``, ``left_elbow``, ``right_elbow``,
+``left_wrist``, ``right_wrist``, ``left_hip``, ``right_hip``, ``left_knee``,
+``right_knee``, ``left_ankle`` and ``right_ankle``.
+
 ## Backend analytics
 
 The backend exposes a WebSocket endpoint at `/pose`. It captures webcam frames

--- a/frontend/src/__tests__/poseDrawing.test.tsx
+++ b/frontend/src/__tests__/poseDrawing.test.tsx
@@ -18,7 +18,7 @@ const makeCtx = () => {
 
 test('drawSkeleton connects edge landmarks', () => {
   const ctx = makeCtx();
-  const landmarks: Point[] = Array.from({ length: 29 }, (_, i) => ({
+  const landmarks: Point[] = Array.from({ length: 17 }, (_, i) => ({
     x: i / 100,
     y: i / 100,
   }));
@@ -34,4 +34,22 @@ test('drawSkeleton connects edge landmarks', () => {
     expect(l[0]).toBeCloseTo(e.x * 100);
     expect(l[1]).toBeCloseTo(e.y * 100);
   });
+});
+
+test('edges list matches 17-point skeleton', () => {
+  const expected: [number, number][] = [
+    [5, 7],
+    [7, 9],
+    [6, 8],
+    [8, 10],
+    [5, 6],
+    [11, 12],
+    [5, 11],
+    [6, 12],
+    [11, 13],
+    [13, 15],
+    [12, 14],
+    [14, 16],
+  ];
+  expect(EDGES).toEqual(expected);
 });

--- a/frontend/src/utils/poseDrawing.ts
+++ b/frontend/src/utils/poseDrawing.ts
@@ -7,18 +7,18 @@ export interface Point {
  * Index pairs describing how to connect the pose landmarks.
  */
 export const EDGES: [number, number][] = [
+  [5, 7],
+  [7, 9],
+  [6, 8],
+  [8, 10],
+  [5, 6],
+  [11, 12],
+  [5, 11],
+  [6, 12],
   [11, 13],
   [13, 15],
   [12, 14],
   [14, 16],
-  [11, 12],
-  [11, 23],
-  [12, 24],
-  [23, 24],
-  [23, 25],
-  [25, 27],
-  [24, 26],
-  [26, 28],
 ];
 
 export function drawSkeleton(

--- a/tests/backend/test_pose_detector.py
+++ b/tests/backend/test_pose_detector.py
@@ -27,6 +27,29 @@ def test_process_success(monkeypatch):
     assert result[0]["x"] == 1.0
 
 
+def test_landmarks_constant():
+    expected = [
+        mp.solutions.pose.PoseLandmark.NOSE,
+        mp.solutions.pose.PoseLandmark.LEFT_EYE,
+        mp.solutions.pose.PoseLandmark.RIGHT_EYE,
+        mp.solutions.pose.PoseLandmark.LEFT_EAR,
+        mp.solutions.pose.PoseLandmark.RIGHT_EAR,
+        mp.solutions.pose.PoseLandmark.LEFT_SHOULDER,
+        mp.solutions.pose.PoseLandmark.RIGHT_SHOULDER,
+        mp.solutions.pose.PoseLandmark.LEFT_ELBOW,
+        mp.solutions.pose.PoseLandmark.RIGHT_ELBOW,
+        mp.solutions.pose.PoseLandmark.LEFT_WRIST,
+        mp.solutions.pose.PoseLandmark.RIGHT_WRIST,
+        mp.solutions.pose.PoseLandmark.LEFT_HIP,
+        mp.solutions.pose.PoseLandmark.RIGHT_HIP,
+        mp.solutions.pose.PoseLandmark.LEFT_KNEE,
+        mp.solutions.pose.PoseLandmark.RIGHT_KNEE,
+        mp.solutions.pose.PoseLandmark.LEFT_ANKLE,
+        mp.solutions.pose.PoseLandmark.RIGHT_ANKLE,
+    ]
+    assert pd.PoseDetector.LANDMARKS == expected
+
+
 def test_process_none():
     det = pd.PoseDetector()
     try:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,6 +16,31 @@ def test_build_payload_format():
     assert {"knee_angle", "balance", "pose_class"} <= metrics.keys()
 
 
+def test_names_match_landmarks():
+    import backend.server as server
+
+    expected = [
+        "nose",
+        "left_eye",
+        "right_eye",
+        "left_ear",
+        "right_ear",
+        "left_shoulder",
+        "right_shoulder",
+        "left_elbow",
+        "right_elbow",
+        "left_wrist",
+        "right_wrist",
+        "left_hip",
+        "right_hip",
+        "left_knee",
+        "right_knee",
+        "left_ankle",
+        "right_ankle",
+    ]
+    assert server._NAMES == expected
+
+
 def test_server_starts():
     proc = subprocess.Popen(
         [sys.executable, "-m", "backend.server"],


### PR DESCRIPTION
## Summary
- define a `PoseDetector.LANDMARKS` list with explicit `PoseLandmark` enums
- stream landmark names from the server using that subset
- redraw skeleton edges for the 17‑point layout
- document keypoint ordering in README and docs
- extend backend and frontend tests for the new mapping

## Testing
- `make lint`
- `make typecheck`
- `make test`
- `pre-commit` *(fails: Username for 'https://github.com')*

------
https://chatgpt.com/codex/tasks/task_e_6876452c73d88325937e7cd8edd1c2fa