### PR TITLE
Add WebSocket status hook

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -874,3 +874,10 @@ by reinitialising the pose detector per connection.
 - **Stage**: implementation
 - **Motivation / Decision**: display full analytics to users per feature request.
 - **Next step**: none.
+
+### 2025-07-15  PR #109
+
+- **Summary**: WebSocket hook now exposes connection status and PoseViewer displays it.
+- **Stage**: implementation
+- **Motivation / Decision**: give users feedback on backend connectivity; tests cover open and close events.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ npm test
 The PoseViewer component shows the live webcam feed. Use the **Start Webcam**
 button to toggle the stream. A canvas overlay draws lines between keypoints to
 show the pose skeleton.
+The `useWebSocket` hook returns the latest pose data and a connection state
+(`connecting`, `open`, `closed` or `error`). PoseViewer displays this state so
+you know if the backend is reachable.
 
 ## Running locally
 

--- a/TODO.md
+++ b/TODO.md
@@ -109,3 +109,4 @@
 - [x] Draw skeleton edges in the PoseViewer canvas overlay.
 - [x] Stream 17 keypoints via PoseDetector and close resources.
 - [x] Display knee angle in MetricsPanel with tests.
+- [x] Show WebSocket connection status in the UI.

--- a/frontend/src/__tests__/useWebSocket.test.tsx
+++ b/frontend/src/__tests__/useWebSocket.test.tsx
@@ -1,4 +1,6 @@
-import { resolveUrl } from '../hooks/useWebSocket';
+import { renderHook, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import useWebSocket, { resolveUrl } from '../hooks/useWebSocket';
 
 test('defaults to port 8000 when no protocol is given', () => {
   Object.defineProperty(window, 'location', {
@@ -6,5 +8,45 @@ test('defaults to port 8000 when no protocol is given', () => {
     writable: true,
   });
   expect(resolveUrl('/pose')).toBe('ws://example.com:8000/pose');
+});
+
+class MockWebSocket {
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  constructor(public url: string) {}
+  triggerOpen() {
+    this.onopen?.();
+  }
+  triggerClose() {
+    this.onclose?.();
+  }
+  close() {
+    this.triggerClose();
+  }
+}
+
+test('status changes on open and close events', async () => {
+  const ws = new MockWebSocket('ws://test');
+  const OriginalWebSocket = window.WebSocket;
+  // @ts-ignore
+  window.WebSocket = jest.fn(() => ws);
+
+  const { result } = renderHook(() => useWebSocket('/pose'));
+
+  expect(result.current.status).toBe('connecting');
+
+  act(() => {
+    ws.triggerOpen();
+  });
+  expect(result.current.status).toBe('open');
+
+  act(() => {
+    ws.triggerClose();
+  });
+  expect(result.current.status).toBe('closed');
+
+  window.WebSocket = OriginalWebSocket;
 });
 

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -11,7 +11,7 @@ interface PoseData {
 const PoseViewer: React.FC = () => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const { poseData } = useWebSocket<PoseData>('/pose');
+  const { poseData, status } = useWebSocket<PoseData>('/pose');
   const [streaming, setStreaming] = useState(true);
   const streamRef = useRef<MediaStream | null>(null);
 
@@ -61,6 +61,7 @@ const PoseViewer: React.FC = () => {
       <video ref={videoRef} autoPlay muted />
       <canvas ref={canvasRef} width={640} height={480} />
       <MetricsPanel data={poseData?.metrics} />
+      <div className="connection-status">Connection: {status}</div>
       <button onClick={() => setStreaming((s) => !s)}>
         {streaming ? 'Stop Webcam' : 'Start Webcam'}
       </button>


### PR DESCRIPTION
## Summary
- track WebSocket connection status in `useWebSocket`
- show connection state in PoseViewer
- test connection state transitions
- document new behaviour
- tick TODO and log change

## Testing
- `make lint`
- `make typecheck`
- `make test`
- *pre-commit run --files* *(failed: asked for GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_687645411f78832581c525403e698d19