### PR TITLE
Fix pre-commit install path

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -39,9 +39,9 @@ python3 -m pip install pre-commit
 
 # install hooks into the shared cache while network is available
 if [ -f .pre-commit-config.yaml ] && [ "${SKIP_PRECOMMIT:-0}" != "1" ]; then
-  pre-commit install --install-hooks --overwrite --config=.pre-commit-config.yaml
-  pre-commit install --install-hooks --overwrite
-  pre-commit run --all-files || true
+  python3 -m pre_commit install --install-hooks --overwrite --config=.pre-commit-config.yaml
+  python3 -m pre_commit install --install-hooks --overwrite
+  python3 -m pre_commit run --all-files || true
 fi
 
 npm install

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.31 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.32 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -64,7 +64,8 @@ prevents GitHub prompts.
     `.github/workflows/ci.yml` (see § 4) so forks without secrets still pass.
 4. On the first PR, update README badges to point at your fork (owner/repo).
 5. `.codex/setup.sh` installs `pre-commit` and sets up the hooks automatically
-   on the first run.
+   using `python3 -m pre_commit` on the first run. This avoids PATH issues when
+   the command is not yet on `$PATH`.
    Set `SKIP_PRECOMMIT=1` to bypass this when offline. The CI workflow passes
    this flag because the runners have restricted network access.
 
@@ -80,7 +81,7 @@ prevents GitHub prompts.
    make lint                  # all format / static‑analysis steps
    make typecheck             # mypy static type checking
    make test                  # unit/integration tests with coverage ≥80%
-   pre-commit run --files <changed>
+   python3 -m pre_commit run --files <changed>
    ```
 
     - For docs-only changes run `make lint` (or `make lint-docs`) before committing.

--- a/NOTES.md
+++ b/NOTES.md
@@ -891,3 +891,10 @@ backend connectivity; tests cover open and close events.
 - **Motivation / Decision**: align keypoint order with tech challenge and expose
   named mapping across backend and frontend.
 - **Next step**: none.
+
+### 2025-07-19  PR #111
+
+- **Summary**: Setup script installs hooks using `python3 -m pre_commit`.
+- **Stage**: maintenance
+- **Motivation / Decision**: avoid PATH issues when `pre-commit` is not on PATH.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -111,3 +111,4 @@
 - [x] Display knee angle in MetricsPanel with tests.
 - [x] Show WebSocket connection status in the UI.
 - [x] Use PoseLandmark names for 17 keypoints across backend and frontend.
+- [x] Setup script calls `python3 -m pre_commit` to install hooks.


### PR DESCRIPTION
## Summary
- use `python3 -m pre_commit` when installing hooks
- mention new invocation in AGENTS
- record the change in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `SKIP_PRECOMMIT=1 .codex/setup.sh`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6877573025f48325bd46c092afda491b