### PR TITLE
Add markdownlintignore and update agents

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,4 @@
+node_modules/
+.pre-commit-cache/
+frontend/dist/
+docs/_build/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.32 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.33 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -94,6 +94,7 @@ prevents GitHub prompts.
       verify pinned versions exist. CI runs this automatically when
       `requirements.txt`, `package.json` or `package-lock.json` change.
     - Run `make docs` to build the HTML docs into `docs/_build`.
+    - Markdownlint reads `.markdownlintignore` to skip build and cache dirs.
     - Python code under `scripts/` and `tests/` is linted with `ruff` via `make lint`.
     - Static type checking uses mypy via `make typecheck`.
     - Python code in `backend/`, `scripts/` and `tests/` is formatted with `black`

--- a/NOTES.md
+++ b/NOTES.md
@@ -898,3 +898,10 @@ backend connectivity; tests cover open and close events.
 - **Stage**: maintenance
 - **Motivation / Decision**: avoid PATH issues when `pre-commit` is not on PATH.
 - **Next step**: none.
+
+### 2025-07-20  PR #112
+
+- **Summary**: Added `.markdownlintignore` and mentioned it in `AGENTS.md`.
+- **Stage**: maintenance
+- **Motivation / Decision**: speed up markdown linting by skipping build folders.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO – Road‑map (last updated: 2025-07-15)
+# TODO – Road‑map (last updated: 2025-07-20)
 
 > *Record only high‑level milestones here; break micro‑tasks out into Issues.*  
 > **When you finish a task, tick it and append a short NOTE entry
@@ -112,3 +112,4 @@
 - [x] Show WebSocket connection status in the UI.
 - [x] Use PoseLandmark names for 17 keypoints across backend and frontend.
 - [x] Setup script calls `python3 -m pre_commit` to install hooks.
+- [x] Add .markdownlintignore and update AGENTS accordingly.


### PR DESCRIPTION
## Summary
- add `.markdownlintignore` with build & cache directories
- mention the file in `AGENTS.md` and bump version
- log the change in `NOTES.md`
- update road-map in `TODO.md`

## Testing
- `make lint-docs`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687771678784832595655bfd5cd45f1e