### PR TITLE
Remove unused httpx pin

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -898,3 +898,10 @@ backend connectivity; tests cover open and close events.
 - **Stage**: maintenance
 - **Motivation / Decision**: avoid PATH issues when `pre-commit` is not on PATH.
 - **Next step**: none.
+
+### 2025-07-21  PR #112
+
+- **Summary**: Removed httpx pin from requirements; verified all other pins.
+- **Stage**: maintenance
+- **Motivation / Decision**: dependency unused so cleaned up to reduce overhead.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO – Road‑map (last updated: 2025-07-15)
+# TODO – Road‑map (last updated: 2025-07-16)
 
 > *Record only high‑level milestones here; break micro‑tasks out into Issues.*  
 > **When you finish a task, tick it and append a short NOTE entry
@@ -112,3 +112,4 @@
 - [x] Show WebSocket connection status in the UI.
 - [x] Use PoseLandmark names for 17 keypoints across backend and frontend.
 - [x] Setup script calls `python3 -m pre_commit` to install hooks.
+- [x] Remove httpx pin from requirements.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ opencv-python==4.10.0.82
 mediapipe==0.10.13
 ruff==0.4.4
 websockets==15.0.1
-httpx==0.27.0
 pytest-cov==6.2.1
 pytest==8.2.0
 sphinx==7.2.6


### PR DESCRIPTION
## Summary
- remove `httpx==0.27.0` from `requirements.txt`
- update TODO roadmap
- log the change in NOTES
- verify version pins

## Testing
- `make check-versions`
- `make lint`
- `make typecheck`
- `make test`
- `python3 -m pre_commit run --files NOTES.md TODO.md requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6877714190d483258da0ab2dccaee8c6