### PR TITLE
Format docs config and lint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.32 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.33 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -96,8 +96,9 @@ prevents GitHub prompts.
     - Run `make docs` to build the HTML docs into `docs/_build`.
     - Python code under `scripts/` and `tests/` is linted with `ruff` via `make lint`.
     - Static type checking uses mypy via `make typecheck`.
-    - Python code in `backend/`, `scripts/` and `tests/` is formatted with `black`
-      and linted with `ruff` via `make lint`.
+    - Python code in `backend/`, `scripts/`, `tests/`, and `docs/` is
+      formatted with `black`. `ruff` still checks only `backend/`, `scripts/`
+      and `tests/` via `make lint`.
     - GitHub Actions workflows are linted with
       `actionlint` pinned at v1.7.7 via pre-commit.
     - `make test` expects dependencies from `.codex/setup.sh`.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 lint:
 	npx --yes markdownlint-cli **/*.md
-	black --check backend scripts tests
+	black --check backend scripts tests docs
 	ruff check backend scripts tests
 
 lint-docs: lint

--- a/NOTES.md
+++ b/NOTES.md
@@ -898,3 +898,12 @@ backend connectivity; tests cover open and close events.
 - **Stage**: maintenance
 - **Motivation / Decision**: avoid PATH issues when `pre-commit` is not on PATH.
 - **Next step**: none.
+
+### 2025-07-20  PR #112
+
+- **Summary**: Formatted Sphinx config with Black and updated Makefile to
+  lint docs.
+- **Stage**: maintenance
+- **Motivation / Decision**: keep documentation Python files consistent and
+  ensure lint checks them.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO – Road‑map (last updated: 2025-07-15)
+# TODO – Road‑map (last updated: 2025-07-16)
 
 > *Record only high‑level milestones here; break micro‑tasks out into Issues.*  
 > **When you finish a task, tick it and append a short NOTE entry
@@ -112,3 +112,4 @@
 - [x] Show WebSocket connection status in the UI.
 - [x] Use PoseLandmark names for 17 keypoints across backend and frontend.
 - [x] Setup script calls `python3 -m pre_commit` to install hooks.
+- [x] Format `docs/source/conf.py` with Black and extend `make lint` to check `docs/`.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,25 +6,25 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'PoseDetection'
-copyright = '2025, Pose Team'
-author = 'Pose Team'
+project = "PoseDetection"
+copyright = "2025, Pose Team"
+author = "Pose Team"
 
-version = '0.1'
-release = '0.1'
+version = "0.1"
+release = "0.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = []
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 exclude_patterns = []
 
-language = 'en'
+language = "en"
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'alabaster'
-html_static_path = ['_static']
+html_theme = "alabaster"
+html_static_path = ["_static"]


### PR DESCRIPTION
## Summary
- format `docs/source/conf.py` with Black
- run Black on docs in `make lint`
- document new lint rule in `AGENTS.md`
- record work in `NOTES.md` and tick off `TODO.md`

## Testing
- `make lint`
- `make typecheck`
- `make test`
- `make lint-docs`


------
https://chatgpt.com/codex/tasks/task_e_6877716b1a0c832586bd35eb675037dd