### PR TITLE
Fix README build description

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -925,3 +925,10 @@ backend connectivity; tests cover open and close events.
 - **Stage**: maintenance
 - **Motivation / Decision**: keep roadmap timestamp accurate.
 - **Next step**: none.
+
+### 2025-07-16  PR #116
+
+- **Summary**: README clarifies build only outputs bundle.js.
+  `index.html` is already there.
+- **Stage**: documentation
+- **Motivation / Decision**: correct outdated build instructions.

--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ Start the backend with:
 python -m backend.server
 ```
 
-`npm run build` bundles the app to `frontend/dist/bundle.js` and copies
-`index.html` alongside it. Serve the frontend in another terminal:
+`npm run build` bundles the app to `frontend/dist/bundle.js`. The
+`index.html` file is already present in that directory. Serve the frontend
+in another terminal:
 
 ```bash
 npm run build

--- a/TODO.md
+++ b/TODO.md
@@ -115,3 +115,4 @@
 - [x] Remove httpx pin from requirements.
 - [x] Add .markdownlintignore and update AGENTS accordingly.
 - [x] Document Node 20 requirement in README and package.json.
+- [x] Clarify `npm run build` output in README; index.html already provided.


### PR DESCRIPTION
## Summary
- clarify that npm build only outputs bundle.js
- note this in roadmap
- record documentation update in notes

## Testing
- `make lint-docs`

------
https://chatgpt.com/codex/tasks/task_e_687771a6b62483258c521ebacc012c6f