### PR TITLE
Improve lint-docs conflict marker check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.33 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.34 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -93,7 +93,8 @@ prevents GitHub prompts.
     - Always run `make lint-docs` after editing any Markdown file
       to avoid CI failures.
     - `make lint-docs` only runs `markdownlint` and a conflict marker check,
-      so it finishes quickly.
+      so it finishes quickly. The check skips `node_modules`, `.pre-commit-cache`,
+      `frontend/dist` and `docs/_build`.
     - Run `make check-versions` when changing dependencies to
       verify pinned versions exist. CI runs this automatically when
       `requirements.txt`, `package.json` or `package-lock.json` change.
@@ -169,7 +170,10 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           npx --yes markdownlint-cli '**/*.md'
-          grep -R --line-number -E '<{7}|={7}|>{7}' --exclude=ci.yml . && exit 1 || echo "No conflict markers"
+          grep -R --line-number -E '<{7}|={7}|>{7}' --exclude=ci.yml \
+            --exclude-dir=node_modules --exclude-dir=.pre-commit-cache \
+            --exclude-dir=frontend/dist --exclude-dir=docs/_build . && exit 1 \
+            || echo "No conflict markers"
 
   markdown-link-check:
     needs: [changes]

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,10 @@ lint:
 
 lint-docs:
 	npx --yes markdownlint-cli '**/*.md'
-	grep -R --line-number -E '<{7}|={7}|>{7}' --exclude=ci.yml . && exit 1 || echo "No conflict markers"
+	grep -R --line-number -E '<{7}|={7}|>{7}' --exclude=ci.yml \
+	  --exclude-dir=node_modules --exclude-dir=.pre-commit-cache \
+	  --exclude-dir=frontend/dist --exclude-dir=docs/_build . && exit 1 \
+	  || echo "No conflict markers"
 
 test:
 	@if [ -d tests ]; then \

--- a/NOTES.md
+++ b/NOTES.md
@@ -934,6 +934,7 @@ backend connectivity; tests cover open and close events.
   ensure lint checks them.
 
 ### 2025-07-20  PR #117
+
 - **Summary**: Added edge case test for PoseDetector when no landmarks are found.
 - **Stage**: testing
 - **Motivation / Decision**: reach 100% coverage of pose_detector module.
@@ -971,3 +972,10 @@ backend connectivity; tests cover open and close events.
   `index.html` is already there.
 - **Stage**: documentation
 - **Motivation / Decision**: correct outdated build instructions.
+
+### 2025-07-16  PR #122
+
+- **Summary**: lint-docs grep now skips build and cache dirs; documented in
+  AGENTS.
+- **Stage**: maintenance
+- **Motivation / Decision**: avoid false positives from node_modules.

--- a/TODO.md
+++ b/TODO.md
@@ -121,3 +121,4 @@
 - [x] Add .markdownlintignore and update AGENTS accordingly.
 - [x] Document Node 20 requirement in README and package.json.
 - [x] Clarify `npm run build` output in README; index.html already provided.
+- [x] Exclude build directories from conflict marker check in `lint-docs`.


### PR DESCRIPTION
## Summary
- skip build directories in lint-docs conflict marker search
- document lint-docs exclusions in AGENTS guide
- record change in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make test`
- `make lint-docs`


------
https://chatgpt.com/codex/tasks/task_e_68777a51de5083258195b17e8fe65efd