### PR TITLE
Fix lint to format docs with Black

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 lint:
 	npx --yes markdownlint-cli '**/*.md' --ignore node_modules --ignore .pre-commit-cache --ignore frontend/dist --ignore docs/_build
-	black --check backend scripts tests
+	black --check backend scripts tests docs
 	ruff check backend scripts tests
 
 lint-docs:

--- a/NOTES.md
+++ b/NOTES.md
@@ -934,6 +934,7 @@ backend connectivity; tests cover open and close events.
   ensure lint checks them.
 
 ### 2025-07-20  PR #117
+
 - **Summary**: Added edge case test for PoseDetector when no landmarks are found.
 - **Stage**: testing
 - **Motivation / Decision**: reach 100% coverage of pose_detector module.
@@ -971,3 +972,12 @@ backend connectivity; tests cover open and close events.
   `index.html` is already there.
 - **Stage**: documentation
 - **Motivation / Decision**: correct outdated build instructions.
+
+### 2025-07-16  PR #139
+
+- **Summary**: restored Black check for docs in Makefile.
+- **Stage**: maintenance
+- **Motivation / Decision**: AGENTS guide
+ states docs Python must be formatted with Black,
+but the lint step lost this path.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -121,3 +121,4 @@
 - [x] Add .markdownlintignore and update AGENTS accordingly.
 - [x] Document Node 20 requirement in README and package.json.
 - [x] Clarify `npm run build` output in README; index.html already provided.
+- [x] Restored black formatting for docs in Makefile.


### PR DESCRIPTION
## Summary
- ensure Makefile runs `black` on `docs/`
- log the decision in NOTES
- track the maintenance task in TODO

## Testing
- `make lint`
- `make typecheck`
- `make test`
- `pre-commit run --files Makefile NOTES.md TODO.md`


------
https://chatgpt.com/codex/tasks/task_e_68777a3cc2b083258f5b5ca1f2a780df