### PR TITLE
docs: fix missing blank line in log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,8 @@ prevents GitHub prompts.
       to avoid CI failures.
     - `make lint-docs` only runs `markdownlint` and a conflict marker check,
       so it finishes quickly.
+    - If it fails with binary file matches, delete `node_modules/` and
+      `.pre-commit-cache/` before rerunning.
     - Run `make check-versions` when changing dependencies to
       verify pinned versions exist. CI runs this automatically when
       `requirements.txt`, `package.json` or `package-lock.json` change.

--- a/NOTES.md
+++ b/NOTES.md
@@ -934,6 +934,7 @@ backend connectivity; tests cover open and close events.
   ensure lint checks them.
 
 ### 2025-07-20  PR #117
+
 - **Summary**: Added edge case test for PoseDetector when no landmarks are found.
 - **Stage**: testing
 - **Motivation / Decision**: reach 100% coverage of pose_detector module.
@@ -971,3 +972,9 @@ backend connectivity; tests cover open and close events.
   `index.html` is already there.
 - **Stage**: documentation
 - **Motivation / Decision**: correct outdated build instructions.
+
+### 2025-07-22  PR #122
+
+- **Summary**: Inserted blank line after PR #117 heading for markdownlint.
+- **Stage**: documentation
+- **Motivation / Decision**: maintain consistent log formatting.


### PR DESCRIPTION
## Summary
- insert missing blank line after `### 2025-07-20  PR #117`
- log the change in `NOTES.md`
- mention clearing cache folders in `AGENTS.md` when `make lint-docs` fails

## Testing
- `make lint-docs`

------
https://chatgpt.com/codex/tasks/task_e_68777a48cc948325bc226ecc5dd9cf6c