### PR TITLE
Add TypeScript typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,5 @@ jobs:
         run: python -m pip install -r requirements.txt
       - run: make lint
       - run: make typecheck
+      - run: make typecheck-ts
       - run: make test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.33 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.34 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -81,6 +81,7 @@ prevents GitHub prompts.
    ```bash
    make lint                  # all format / static‑analysis steps
    make typecheck             # mypy static type checking
+   make typecheck-ts          # TypeScript compile check
    make test                  # unit/integration tests with coverage ≥80%
    python3 -m pre_commit run --files <changed>
    ```
@@ -101,6 +102,7 @@ prevents GitHub prompts.
     - Markdownlint reads `.markdownlintignore` to skip build and cache dirs.
     - Python code under `scripts/` and `tests/` is linted with `ruff` via `make lint`.
     - Static type checking uses mypy via `make typecheck`.
+    - TypeScript compile checks run via `make typecheck-ts`.
     - Python code in `backend/`, `scripts/`, `tests/`, and `docs/` is
       formatted with `black`. `ruff` still checks only `backend/`, `scripts/`
       and `tests/` via `make lint`.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint lint-docs test generate docs typecheck
+.PHONY: lint lint-docs test generate docs typecheck typecheck-ts
 
 lint:
 	npx --yes markdownlint-cli '**/*.md' --ignore node_modules --ignore .pre-commit-cache --ignore frontend/dist --ignore docs/_build
@@ -26,6 +26,9 @@ generate:
 
 typecheck:
 	mypy backend
+
+typecheck-ts:
+	npx --yes tsc --noEmit -p frontend/tsconfig.json
 
 update-todo-date:
 	python scripts/update_todo_date.py

--- a/NOTES.md
+++ b/NOTES.md
@@ -934,6 +934,7 @@ backend connectivity; tests cover open and close events.
   ensure lint checks them.
 
 ### 2025-07-20  PR #117
+
 - **Summary**: Added edge case test for PoseDetector when no landmarks are found.
 - **Stage**: testing
 - **Motivation / Decision**: reach 100% coverage of pose_detector module.
@@ -971,3 +972,10 @@ backend connectivity; tests cover open and close events.
   `index.html` is already there.
 - **Stage**: documentation
 - **Motivation / Decision**: correct outdated build instructions.
+
+### 2025-07-16  PR #122
+
+- **Summary**: added TypeScript type checking via `make typecheck-ts` and CI step.
+- **Stage**: implementation
+- **Motivation / Decision**: ensure frontend code passes `tsc` before commit.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ indicating ``standing`` or ``sitting``.
 ## Development
 
 Run `make lint` to check Markdown and Python code style (ruff).
+Run `make typecheck-ts` to compile the frontend TypeScript.
 Run `make test` to execute the test-suite.
 CI runs `make check-versions` whenever dependency files change to
 ensure pinned versions are valid.

--- a/TODO.md
+++ b/TODO.md
@@ -121,3 +121,4 @@
 - [x] Add .markdownlintignore and update AGENTS accordingly.
 - [x] Document Node 20 requirement in README and package.json.
 - [x] Clarify `npm run build` output in README; index.html already provided.
+- [x] Add TypeScript type checking via `make typecheck-ts` and run it in CI.


### PR DESCRIPTION
## Summary
- add `typecheck-ts` target that runs `npx --yes tsc --noEmit -p frontend/tsconfig.json`
- run the new target in CI after Python typecheck
- document the step in the dev guide
- remind contributors to run `make typecheck-ts` in AGENTS
- log the change in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`
- `make lint-docs`


------
https://chatgpt.com/codex/tasks/task_e_68777a188b748325a83da37df9cdb94a