### PR TITLE
Fix Makefile lint-docs rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,15 @@ lint:
 
 lint-docs:
 	npx --yes markdownlint-cli '**/*.md'
-  grep -R --line-number -E '<{7}|={7}|>{7}' \
-    --exclude=ci.yml \
-    --exclude-dir=node_modules \
-    --exclude-dir=.pre-commit-cache \
-    --exclude-dir=frontend/dist \
-    --exclude-dir=docs/_build \
-    . \
-    && exit 1 \
-    || echo "No conflict markers"
+	grep -R --line-number -E '<{7}|={7}|>{7}' \
+	  --exclude=ci.yml \
+	  --exclude-dir=node_modules \
+	  --exclude-dir=.pre-commit-cache \
+	  --exclude-dir=frontend/dist \
+	  --exclude-dir=docs/_build \
+	  . \
+	  && exit 1 \
+	  || echo "No conflict markers"
 
 test:
 	@if [ -d tests ]; then \

--- a/NOTES.md
+++ b/NOTES.md
@@ -1024,3 +1024,10 @@ but the lint step lost this path.
 - **Stage**: maintenance
 - **Motivation / Decision**: prevent event loop blocking when multiple
   clients connect and ensure graceful shutdown.
+
+### 2025-07-16  PR #130
+
+- **Summary**: fixed `lint-docs` rule indentation so Makefile executes.
+- **Stage**: maintenance
+- **Motivation / Decision**: Makefile failed due to spaces; used tabs instead.
+- **Next step**: none.


### PR DESCRIPTION
## Summary
- fix indentation under `lint-docs` rule in Makefile
- update NOTES

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`
- `make lint-docs`
- `python3 -m pre_commit run --files Makefile NOTES.md`

------
https://chatgpt.com/codex/tasks/task_e_6877868437388325bcc13e9b2b64b112