### PR TITLE
Add server performance test

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1038,3 +1038,11 @@ but the lint step lost this path.
 - **Stage**: maintenance
 - **Motivation / Decision**: Makefile failed due to spaces; used tabs instead.
 - **Next step**: none.
+
+### 2025-07-16  PR #132
+
+- **Summary**: added performance test using dummy webcam and detector.
+- **Stage**: testing
+- **Motivation / Decision**: ensure pose_endpoint handles frames at 20 FPS and
+  WebSocket latency below 200 ms.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -127,3 +127,4 @@
 - [x] Add test for zero-length vector in `calculate_angle`.
 - [x] Handle concurrent `/pose` WebSocket clients without blocking.
 - [x] Match CI lint-docs grep excludes with AGENTS guidance.
+- [x] Add performance test for pose_endpoint measuring frame loop time and round-trip.

--- a/tests/performance/test_server_performance.py
+++ b/tests/performance/test_server_performance.py
@@ -1,0 +1,81 @@
+import asyncio
+import time
+from typing import Any
+
+import backend.server as server
+
+
+class DummyCap:
+    def __init__(self, frames: int, times: list[float]) -> None:
+        self._frames = frames
+        self.released = False
+        self.times = times
+
+    def read(self) -> tuple[bool, Any]:
+        if self._frames <= 0:
+            return False, None
+        self._frames -= 1
+        self.times.append(time.perf_counter())
+        return True, object()
+
+    def release(self) -> None:
+        self.released = True
+
+
+class DummyDetector:
+    def process(self, frame: Any) -> list[dict[str, float]]:
+        return [{"x": 0.0, "y": 0.0, "visibility": 1.0}] * 17
+
+    def close(self) -> None:
+        pass
+
+
+class DummyWS:
+    def __init__(self, times: list[float]) -> None:
+        self.accepted = False
+        self.sent: list[str] = []
+        self.times = times
+        self.closed = False
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def send_text(self, text: str) -> None:
+        self.sent.append(text)
+        self.times.append(time.perf_counter())
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+async def _dummy_read_frame(cap: DummyCap) -> tuple[bool, Any]:
+    return cap.read()
+
+
+async def _dummy_process(det: DummyDetector, frame: Any) -> list[dict[str, float]]:
+    return det.process(frame)
+
+
+def test_pose_endpoint_performance(monkeypatch: Any) -> None:
+    frame_count = 10
+    cap_times: list[float] = []
+    ws_times: list[float] = []
+
+    monkeypatch.setattr(server, "_read_frame", _dummy_read_frame)
+    monkeypatch.setattr(server, "_process", _dummy_process)
+    monkeypatch.setattr(
+        server.cv2, "VideoCapture", lambda *_a, **_k: DummyCap(frame_count, cap_times)
+    )
+    monkeypatch.setattr(server, "PoseDetector", lambda *_a, **_k: DummyDetector())
+
+    ws = DummyWS(ws_times)
+    asyncio.run(server.pose_endpoint(ws))
+
+    assert ws.closed
+    assert len(ws.sent) == frame_count + 1
+    assert len(cap_times) == frame_count
+
+    durations = [ws_times[i] - cap_times[i] for i in range(frame_count)]
+    avg_loop = sum(durations) / frame_count
+    assert avg_loop <= 0.05
+    assert max(durations) < 0.2


### PR DESCRIPTION
## Summary
- add performance test for pose endpoint using dummy capture and detector
- document new task in TODO and log in NOTES

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`
- `python -m pre_commit run --files tests/performance/test_server_performance.py TODO.md NOTES.md`

------
https://chatgpt.com/codex/tasks/task_e_68778b1f5cf48325b1a32b08a90a99d3