### PR TITLE
Document performance tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.34 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.35 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -79,13 +79,13 @@ prevents GitHub prompts.
    (one reviewer required).
 2. **Pre‑commit commands** (also run by CI):
 
-   ```bash
-   make lint                  # all format / static‑analysis steps
-   make typecheck             # mypy static type checking
-   make typecheck-ts          # TypeScript compile check
-   make test                  # unit/integration tests with coverage ≥80%
-   python3 -m pre_commit run --files <changed>
-   ```
+    ```bash
+    make lint                  # all format / static‑analysis steps
+    make typecheck             # mypy static type checking
+    make typecheck-ts          # TypeScript compile check
+    make test                  # unit/integration + perf tests; coverage ≥80%
+    python3 -m pre_commit run --files <changed>
+    ```
 
     - For docs-only changes run `make lint` (or `make lint-docs`) before committing.
     - When updating `NOTES.md` or `TODO.md` run `make lint-docs` to
@@ -113,6 +113,8 @@ prevents GitHub prompts.
     - GitHub Actions workflows are linted with
       `actionlint` pinned at v1.7.7 via pre-commit.
     - `make test` expects dependencies from `.codex/setup.sh`.
+    - Performance tests reside in `tests/performance` and run as part of
+      `make test`. Execute them alone with `pytest tests/performance`.
 3. **Style rules** – keep code formatted (`black`, `prettier`,
    `dart format`, etc.) and Markdown lines ≤ 80 chars;
    avoid multiple consecutive blank lines (markdownlint MD012);

--- a/NOTES.md
+++ b/NOTES.md
@@ -1038,3 +1038,10 @@ but the lint step lost this path.
 - **Stage**: maintenance
 - **Motivation / Decision**: Makefile failed due to spaces; used tabs instead.
 - **Next step**: none.
+
+### 2025-07-16  PR #132
+
+- **Summary**: documented performance tests in AGENTS and README.
+- **Stage**: maintenance
+- **Motivation / Decision**: keep guides up to date with new test suite.
+- **Next step**: plan CI stage for performance metrics.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ indicating ``standing`` or ``sitting``.
 
 Run `make lint` to check Markdown and Python code style (ruff).
 Run `make typecheck-ts` to compile the frontend TypeScript.
-Run `make test` to execute the test-suite.
+Run `make test` to execute the test-suite. Performance tests live in
+`tests/performance` and run automatically. Run them on their own with
+`pytest tests/performance`.
 CI runs `make check-versions` whenever dependency files change to
 ensure pinned versions are valid.
 Pre-commit hooks are installed automatically by `.codex/setup.sh`,


### PR DESCRIPTION
## Summary
- update AGENTS guide with new performance test instructions
- explain running the performance suite in the README
- log these doc updates in NOTES

## Testing
- `make lint-docs`

------
https://chatgpt.com/codex/tasks/task_e_68778b3583a083258a45eaf09139844c