### PR TITLE
Pin black version and update docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.35 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.36 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -72,6 +72,8 @@ prevents GitHub prompts.
    on the first run to avoid PATH issues. Set `SKIP_PRECOMMIT=1` to bypass this
    when offline. The CI workflow passes this flag because the runners have
    restricted network access.
+6. `black` is pinned in `requirements.txt` so `make lint` works when
+   pre-commit hooks are skipped.
 
 ---
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1074,3 +1074,11 @@ errors and maintains coverage.
 - **Motivation / Decision**: ensure pose_endpoint handles frames at 20 FPS and
   WebSocket latency below 200 ms.
 - **Next step**: none.
+
+### 2025-07-17  PR #137
+
+- **Summary**: pinned black in requirements and updated docs for skipping hooks.
+- **Stage**: maintenance
+- **Motivation / Decision**: ensure `make lint` works when pre-commit hooks are
+  skipped.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -66,8 +66,10 @@ Dependabot reviews `requirements.txt`, `package.json` and
 ## Setup
 
 Run `.codex/setup.sh` after cloning to install Python 3.11, Node 20 and all
-project dependencies. Tests rely on these packages, so always complete this
-step before running `make test`. The script is idempotent and exits 0 when
+project dependencies. This installs `black` from `requirements.txt` so
+`make lint` works even when hooks are skipped. Tests rely on these packages,
+so always complete this step before running `make test`. The script is
+idempotent and exits 0 when
 finished. Pre-commit hooks are stored in `.pre-commit-cache/` so they can be
 reused offline. The script then runs `pre-commit run --all-files`, which may
 reformat files, so execute it before making changes.

--- a/TODO.md
+++ b/TODO.md
@@ -131,3 +131,4 @@
 - [x] Add integration test for webcam device reading at least one frame.
 - [x] Add tests for pose_endpoint error cases (no frame, process fail, no landmarks).
 - [x] Add performance test for pose_endpoint measuring frame loop time and round-trip.
+- [x] Pin black version in requirements to allow linting without hooks.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]==0.35.0
 opencv-python==4.10.0.82
 mediapipe==0.10.13
 ruff==0.4.4
+black==24.4.2
 websockets==15.0.1
 pytest-cov==6.2.1
 pytest==8.2.0


### PR DESCRIPTION
## Summary
- pin `black==24.4.2` in requirements
- document black install in README setup section
- note black pin in AGENTS and bump version to 1.36
- tick TODO and add NOTES entry about the change

## Testing
- `make lint-docs`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6878b2834b5c8325ad23042951b051d3