### PR TITLE
Clarify placeholder data for pose accuracy test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.36 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.37 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -37,8 +37,9 @@ document information in code files.
   code-generated. Run `make generate` (calls `python scripts/generate.py`)
   to recreate them and keep these files out of regular commits unless
   intentionally updating the outputs.
-- Sample frames for pose accuracy tests are stored in `tests/data/` and are not tracked.
-  Add PNG images and `labels.json` manually to run the test.
+- Sample frames for pose accuracy tests are stored in `tests/data/`.
+- Placeholder PNG images and a `labels.json` file are provided.
+- Replace them with real frames to run the accuracy test; otherwise it skips.
 - **Search for conflict markers before every commit** –
   `git grep -n -E '<{7}|={7}|>{7}'` must return nothing.
 - **Never include conflict markers verbatim** –

--- a/NOTES.md
+++ b/NOTES.md
@@ -1082,3 +1082,10 @@ errors and maintains coverage.
 - **Motivation / Decision**: ensure `make lint` works when pre-commit hooks are
   skipped.
 - **Next step**: none.
+
+### 2025-07-18  PR #138
+
+- **Summary**: clarified placeholder test data in README and AGENTS.
+- **Stage**: documentation
+- **Motivation / Decision**: docs wrongly asked users to add files manually.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ credentials.
 The Python dependencies install `mediapipe==0.10.13`,
 `websockets==15.0.1` and `numpy==1.26.4`.
 Sample frames for the performance test live in `tests/data/`.
-Add `labels.json` and PNG images before running `pytest`.
-If you want to check pose accuracy.
+Placeholder images and a `labels.json` file are already present.
+The pose accuracy test skips unless you replace them with real frames.
 
 ### Backend server
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO – Road‑map (last updated: 2025-07-16)
+# TODO – Road‑map (last updated: 2025-07-18)
 
 > *Record only high‑level milestones here; break micro‑tasks out into Issues.*
 > **When you finish a task, tick it and append a short NOTE entry
@@ -132,3 +132,4 @@
 - [x] Add tests for pose_endpoint error cases (no frame, process fail, no landmarks).
 - [x] Add performance test for pose_endpoint measuring frame loop time and round-trip.
 - [x] Pin black version in requirements to allow linting without hooks.
+- [x] Clarify placeholder images in tests/data and update docs accordingly.

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -1,8 +1,9 @@
 # Sample data
 
 This directory holds sample PNG frames and labels for performance tests.
-Add files `frame1.png`, `frame2.png`, ... and a `labels.json` file
-before running `pytest`. The images should be small to keep runtime low.
+Placeholder images and a `labels.json` file are provided so the suite runs.
+Replace them with real frames to check accuracy. The images should be small to
+keep runtime low.
 Each entry in `labels.json` must look like:
 
 ```json
@@ -12,4 +13,4 @@ Each entry in `labels.json` must look like:
 ]
 ```
 
-The accuracy test skips when the files are missing.
+The accuracy test skips when real frames are not supplied.


### PR DESCRIPTION
## Summary
- document that `tests/data/` already contains placeholder images and `labels.json`
- note that pose accuracy test skips unless real frames are used
- remove outdated instructions from `tests/data/README.md`
- keep AGENTS.md in sync
- log the change in NOTES and roadmap

## Testing
- `make lint-docs`

------
https://chatgpt.com/codex/tasks/task_e_6878c21ae6648325b63f4aafaed68513