### PR TITLE
Add Dockerfile and container docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.37 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.38 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -77,6 +77,8 @@ prevents GitHub prompts.
    pre-commit hooks are skipped.
 7. When using pyenv, run `pyenv rehash` after package installs so new
    shims are picked up.
+8. A `Dockerfile` sets up Python 3.11 and Node 20. Build it with
+   `docker build -t posedetect .` to run tests in a container.
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+# install Node.js 20
+RUN apt-get update && \
+    apt-get install -y curl gnupg && \
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY package.json package-lock.json ./
+RUN npm install && npm run build
+
+COPY . .
+
+CMD ["bash"]

--- a/NOTES.md
+++ b/NOTES.md
@@ -1102,3 +1102,11 @@ errors and maintains coverage.
 - **Stage**: documentation
 - **Motivation / Decision**: docs wrongly asked users to add files manually.
 - **Next step**: none.
+
+### 2025-07-17  PR #141
+
+- **Summary**: added Dockerfile and container guide to document optional
+  container workflow.
+- **Stage**: tooling
+- **Motivation / Decision**: provide a reproducible dev environment.
+- **Next step**: publish image to a registry.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ finished. Pre-commit hooks are stored in `.pre-commit-cache/` so they can be
 reused offline. The script then runs `pre-commit run --all-files`, which may
 reformat files, so execute it before making changes.
 
+Alternatively build the provided Dockerfile:
+
+```bash
+docker build -t posedetect .
+```
+
+See [docs/CONTAINER.md](docs/CONTAINER.md) for details on running the image.
+
 ## Frontend
 
 The `frontend` folder contains a small React app. Build it and run its tests:

--- a/TODO.md
+++ b/TODO.md
@@ -51,7 +51,7 @@
 
 ## 4 · Stretch goals
 
-- [ ] Containerise dev environment (Dockerfile or dev‑container.json)
+- [x] Containerise dev environment (Dockerfile or dev‑container.json)
 - [ ] Auto‑deploy docs & storybooks on each tag
 - [ ] Publish packages (PyPI, npm, pub.dev) via release workflow
 - [ ] Add optional load‑testing / performance CI stage
@@ -135,3 +135,4 @@
 - [x] Call `pyenv rehash` after installing packages in setup script.
 - [x] Skip pose accuracy test when placeholder dataset lacks landmarks.
 - [x] Clarify placeholder images in tests/data and update docs accordingly.
+- [ ] Publish Docker image to a registry

--- a/docs/CONTAINER.md
+++ b/docs/CONTAINER.md
@@ -1,0 +1,32 @@
+# Container guide
+
+This project ships with a `Dockerfile` so you can run the code without
+installing Python or Node locally.
+
+Build the image:
+
+```bash
+docker build -t posedetect .
+```
+
+Start a shell inside the container:
+
+```bash
+docker run --rm -it posedetect bash
+```
+
+From there you can run tests or start the server:
+
+```bash
+make test
+python -m backend.server
+```
+
+To serve the frontend build inside the container:
+
+```bash
+npm run build
+python -m http.server --directory frontend/dist 8080
+```
+
+Then open <http://localhost:8080/> in your browser.


### PR DESCRIPTION
## Summary
- containerise with a basic Dockerfile
- document how to build and use the container
- mention Docker option in README
- note the Dockerfile in AGENTS guide
- record the change in NOTES and mark TODO

## Testing
- `make lint-docs`
- `make lint && make typecheck && make test`


------
https://chatgpt.com/codex/tasks/task_e_6878c95e7ad48325ab6402e1faaf9f1d