### PR TITLE
Add Python 3.12 to CI

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -8,8 +8,8 @@ mkdir -p "$PRE_COMMIT_HOME"
 cd "$PROJECT_ROOT"
 
 # install toolchains with pinned versions; safe to run multiple times
-PYTHON_VERSION=3.11
-NODE_VERSION=20
+PYTHON_VERSION="${PYTHON_VERSION:-3.11}"
+NODE_VERSION="${NODE_VERSION:-20}"
 
 have_python() {
   command -v python3 >/dev/null 2>&1 && python3 -V | grep -q "$PYTHON_VERSION"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,20 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.md_only != 'true'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ['3.11', '3.12']
+        node: ['20']
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
       - name: Bootstrap
-        run: SKIP_PRECOMMIT=1 ./.codex/setup.sh
+        run: PYTHON_VERSION=${{ matrix.python }} NODE_VERSION=${{ matrix.node }} SKIP_PRECOMMIT=1 ./.codex/setup.sh
       - name: Install Python deps
         run: python -m pip install -r requirements.txt
       - run: make lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.37 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.38 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -60,7 +60,8 @@ prevents GitHub prompts.
 
 1. Run `.codex/setup.sh` (or `./setup.sh`) once after cloning & whenever
    dependencies change. *The script installs Python, Node and all packages
-   needed for tests.* Always complete this step before running any test or
+   needed for tests.* Set `PYTHON_VERSION` or `NODE_VERSION` to override the
+   defaults (3.11 and 20). Always complete this step before running any test or
    build.
 2. Export **required secrets** (`GIT_TOKEN`, `GH_PAGES_TOKEN`, …)
    in the repository/organisation **Secrets** console.
@@ -130,7 +131,7 @@ prevents GitHub prompts.
    CI catches regressions
    (e.g. fail fast when quality gates or metric thresholds aren’t met).
 5. **Version‑pin policy** – pin *major*/*minor* versions for critical runtimes &
-   actions (e.g. `actions/checkout@v4`, `node@20`, `python~=3.11`).
+   actions (e.g. `actions/checkout@v4`, `node@20`, `python@3.11` and `python@3.12`).
 6. **Confirm pinned packages exist** – verify each version listed in
    `requirements.txt`, `package.json` or other manifests is available on
    its package registry before committing.
@@ -210,12 +211,23 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.md_only != 'true'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ['3.11', '3.12']
+        node: ['20']
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
       - name: Bootstrap
-        run: ./.codex/setup.sh   # idempotent; safe when absent
+        run: PYTHON_VERSION=${{ matrix.python }} NODE_VERSION=${{ matrix.node }} ./.codex/setup.sh
       - run: make lint
       - run: make typecheck
+      - run: make typecheck-ts
       - run: make test
 ```
 <!-- markdownlint-enable MD013 -->

--- a/NOTES.md
+++ b/NOTES.md
@@ -1102,3 +1102,12 @@ errors and maintains coverage.
 - **Stage**: documentation
 - **Motivation / Decision**: docs wrongly asked users to add files manually.
 - **Next step**: none.
+
+### 2025-07-17  PR #141
+
+- **Summary**: CI now tests Python 3.11 and 3.12 via a matrix and setup script
+  reads PYTHON_VERSION.
+- **Stage**: maintenance
+- **Motivation / Decision**: verify compatibility across versions with minimal
+  workflow changes.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ Dependabot reviews `requirements.txt`, `package.json` and
 
 ## Setup
 
-Run `.codex/setup.sh` after cloning to install Python 3.11, Node 20 and all
-project dependencies. This installs `black` from `requirements.txt` so
+Run `.codex/setup.sh` after cloning to install Python 3.11 (set
+`PYTHON_VERSION` to override) and Node 20 (set `NODE_VERSION` to change).
+This installs `black` from `requirements.txt` so
 `make lint` works even when hooks are skipped. Tests rely on these packages,
 so always complete this step before running `make test`. The script is
 idempotent and exits 0 when

--- a/TODO.md
+++ b/TODO.md
@@ -35,7 +35,7 @@
 - [x] Write README quick‑start (clone → setup → test)
 - [x] Add full doc build (Sphinx / JSDoc / dart‑doc as applicable)
 - [x] Integrate secret‑detection helper step in CI (`has_token` pattern)
-- [ ] Extend CI matrix for all runtimes (Python, Node, Dart, Rust, …)
+- [x] Extend CI matrix for all runtimes (Python, Node, Dart, Rust, …)
 - [x] Add Actionlint + markdown‑link‑check jobs and pin their versions
 - [ ] Publish docs to GitHub Pages when `GH_PAGES_TOKEN` is present
 


### PR DESCRIPTION
## Summary
- run test job on Python 3.11 and 3.12 with Node 20
- allow setup script to read `PYTHON_VERSION`/`NODE_VERSION`
- document matrix and script options in AGENTS and README
- mark CI matrix TODO done and log the decision

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6878c95fdab48325acffd8e69f023b63