### PR TITLE
Add Pages workflow for docs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+name: Pages
+on:
+  push:
+    branches: [main]
+
+jobs:
+  check_token:
+    runs-on: ubuntu-latest
+    outputs:
+      has_token: ${{ steps.token.outputs.present }}
+    steps:
+      - id: token
+        run: echo "present=${{ secrets.GH_PAGES_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: check_token
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup
+        run: ./.codex/setup.sh
+      - run: make docs
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: docs/_build/html
+
+  deploy:
+    if: needs.check_token.outputs.has_token == 'true'
+    needs: [build, check_token]
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          token: ${{ secrets.GH_PAGES_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.37 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.38 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -66,16 +66,18 @@ prevents GitHub prompts.
    in the repository/organisation **Secrets** console.
 3. Verify the **secret‑detection helper step** in
     `.github/workflows/ci.yml` (see § 4) so forks without secrets still pass.
-4. On the first PR, update README badges to point at your fork (owner/repo).
-5. `.codex/setup.sh` installs `pre-commit`, sets up the hooks and then runs
+4. Pushes to `main` run `.github/workflows/pages.yml` which builds the Sphinx
+   docs and deploys them to GitHub Pages when `GH_PAGES_TOKEN` is present.
+5. On the first PR, update README badges to point at your fork (owner/repo).
+6. `.codex/setup.sh` installs `pre-commit`, sets up the hooks and then runs
    `pre-commit run --all-files`. This may reformat files, so run the script
    before editing anything. Hooks are installed using `python3 -m pre_commit`
    on the first run to avoid PATH issues. Set `SKIP_PRECOMMIT=1` to bypass this
    when offline. The CI workflow passes this flag because the runners have
    restricted network access.
-6. `black` is pinned in `requirements.txt` so `make lint` works when
+7. `black` is pinned in `requirements.txt` so `make lint` works when
    pre-commit hooks are skipped.
-7. When using pyenv, run `pyenv rehash` after package installs so new
+8. When using pyenv, run `pyenv rehash` after package installs so new
    shims are picked up.
 
 ---

--- a/NOTES.md
+++ b/NOTES.md
@@ -1102,3 +1102,10 @@ errors and maintains coverage.
 - **Stage**: documentation
 - **Motivation / Decision**: docs wrongly asked users to add files manually.
 - **Next step**: none.
+
+### 2025-07-17  PR #141
+
+- **Summary**: added Pages workflow to publish docs when GH_PAGES_TOKEN is set.
+- **Stage**: implementation
+- **Motivation / Decision**: automate deployment to GitHub Pages per TODO.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ make docs
 ```
 
 The output appears in `docs/_build/html`.
+Pushes to `main` trigger `.github/workflows/pages.yml` to build these docs and
+deploy them to GitHub Pages when the `GH_PAGES_TOKEN` secret is available.
 
 ## License
 

--- a/TODO.md
+++ b/TODO.md
@@ -37,7 +37,7 @@
 - [x] Integrate secret‑detection helper step in CI (`has_token` pattern)
 - [ ] Extend CI matrix for all runtimes (Python, Node, Dart, Rust, …)
 - [x] Add Actionlint + markdown‑link‑check jobs and pin their versions
-- [ ] Publish docs to GitHub Pages when `GH_PAGES_TOKEN` is present
+- [x] Publish docs to GitHub Pages when `GH_PAGES_TOKEN` is present
 
 ## 3 · Quality & automation
 


### PR DESCRIPTION
## Summary
- build and deploy Sphinx docs with new `pages.yml`
- update AGENTS guide and README
- close roadmap item for publishing docs
- log the change in NOTES

## Testing
- `make lint-docs`
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6878c95d4f1c8325ac980908700ced61