### PR TITLE
Fix typecheck setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.38 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.39 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -78,9 +78,10 @@ prevents GitHub prompts.
    restricted network access.
 7. `black` is pinned in `requirements.txt` so `make lint` works when
    pre-commit hooks are skipped.
-8. When using pyenv, run `pyenv rehash` after package installs so new
+8. `mypy` is pinned in `requirements.txt` so `make typecheck` works.
+9. When using pyenv, run `pyenv rehash` after package installs so new
    shims are picked up.
-8. A `Dockerfile` sets up Python 3.11 and Node 20. Build it with
+10. A `Dockerfile` sets up Python 3.11 and Node 20. Build it with
    `docker build -t posedetect .` to run tests in a container.
 
 ---

--- a/NOTES.md
+++ b/NOTES.md
@@ -1134,3 +1134,11 @@ errors and maintains coverage.
 - **Stage**: tooling
 - **Motivation / Decision**: provide a reproducible dev environment.
 - **Next step**: publish image to a registry.
+
+### 2025-07-17  PR #145
+
+- **Summary**: pinned mypy in requirements and documented the type check step.
+- **Stage**: maintenance
+- **Motivation / Decision**: ensure `make typecheck` works offline and update
+  bootstrap docs.
+- **Next step**: publish Docker image to a registry.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ indicating ``standing`` or ``sitting``.
 ## Development
 
 Run `make lint` to check Markdown and Python code style (ruff).
+Run `make typecheck` to check Python types with mypy.
 Run `make typecheck-ts` to compile the frontend TypeScript.
 Run `make test` to execute the test-suite. Performance tests live in
 `tests/performance` and run automatically. Run them on their own with

--- a/TODO.md
+++ b/TODO.md
@@ -135,4 +135,5 @@
 - [x] Call `pyenv rehash` after installing packages in setup script.
 - [x] Skip pose accuracy test when placeholder dataset lacks landmarks.
 - [x] Clarify placeholder images in tests/data and update docs accordingly.
+- [x] Pin mypy version in requirements so `make typecheck` works offline.
 - [ ] Publish Docker image to a registry

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytest-cov==6.2.1
 pytest==8.2.0
 sphinx==7.2.6
 numpy==1.26.4
+mypy==1.16.1


### PR DESCRIPTION
## Summary
- pin `mypy` version for reliable type checks
- document Python typing command in README
- keep AGENTS setup checklist in sync
- record work in NOTES and TODO

## Testing
- `.codex/setup.sh`
- `make lint`
- `make lint-docs`
- `make typecheck`
- `make typecheck-ts`
- `make test`
- `make check-versions`

------
https://chatgpt.com/codex/tasks/task_e_6878cfc0e7e88325808828225bda431c