### PR TITLE
Add Visual Studio venv instructions

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1149,3 +1149,11 @@ errors and maintains coverage.
 - **Motivation / Decision**: ensure `make typecheck` works offline and update
   bootstrap docs.
 - **Next step**: publish Docker image to a registry.
+
+### 2025-07-18  PR #147
+
+- **Summary**: documented Visual Studio 2022 setup for backend development.
+- **Stage**: documentation
+- **Motivation / Decision**: help Windows users create a venv.
+  Set the server startup file.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ docker build -t posedetect .
 
 See [docs/CONTAINER.md](docs/CONTAINER.md) for details on running the image.
 
+## Visual Studio 2022
+
+Follow these steps to run the backend from Visual Studio:
+
+1. Open the repository folder in VS 2022.
+2. In **Python Environments** choose **Add Environment** → **Virtual
+   Environment** and create a `.venv`.
+3. Install the requirements with `pip install -r requirements.txt`.
+4. Right‑click `backend/server.py` and pick **Set as Startup File**.
+5. Press **F5** to launch the FastAPI server.
+
+Install Node separately to build the React frontend with `npm run build`.
+
 ## Frontend
 
 The `frontend` folder contains a small React app. Build it and run its tests:

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO – Road‑map (last updated: 2025-07-17)
+# TODO – Road‑map (last updated: 2025-07-18)
 
 > *Record only high‑level milestones here; break micro‑tasks out into Issues.*
 > **When you finish a task, tick it and append a short NOTE entry


### PR DESCRIPTION
## Summary
- explain how to create and use a venv in Visual Studio 2022
- remind that Node is required to build the React frontend
- update roadmap date and append log entry

## Testing
- `make lint-docs`


------
https://chatgpt.com/codex/tasks/task_e_68791da36d288325be6ba40182597a6e