### PR TITLE
Add PowerShell setup script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.39 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.40 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -59,10 +59,10 @@ prevents GitHub prompts.
 ## 2 · Bootstrap (first-run) checklist
 
 1. Run `.codex/setup.sh` (or `./setup.sh`) once after cloning & whenever
-   dependencies change. *The script installs Python, Node and all packages
-   needed for tests.* Set `PYTHON_VERSION` or `NODE_VERSION` to override the
-   defaults (3.11 and 20). Always complete this step before running any test or
-   build.
+   dependencies change. Windows users can run `scripts/setup.ps1` in
+   PowerShell. *The script installs Python, Node and all packages needed for
+   tests.* Set `PYTHON_VERSION` or `NODE_VERSION` to override the defaults
+   (3.11 and 20). Always complete this step before running any test or build.
 2. Export **required secrets** (`GIT_TOKEN`, `GH_PAGES_TOKEN`, …)
    in the repository/organisation **Secrets** console.
 3. Verify the **secret‑detection helper step** in

--- a/NOTES.md
+++ b/NOTES.md
@@ -1149,3 +1149,11 @@ errors and maintains coverage.
 - **Motivation / Decision**: ensure `make typecheck` works offline and update
   bootstrap docs.
 - **Next step**: publish Docker image to a registry.
+
+### 2025-07-17  PR #147
+
+- **Summary**: added PowerShell setup script, updated README and AGENTS.
+- **Stage**: implementation
+- **Motivation / Decision**: give Windows users an equivalent setup path and
+  document manual alternatives for environments without PowerShell.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -16,15 +16,18 @@ Additional assumptions and edge cases for the first feature are listed in
 
 ## Quick start
 
-Clone the repository and **run `./.codex/setup.sh` first** to install
-Python and Node packages. The project requires Node 20 or newer.
+Clone the repository and run the setup script to install Python and Node
+packages.
+On Linux or macOS use **`./.codex/setup.sh`**. Windows users can run
+**`scripts/setup.ps1`** from PowerShell.
+The project requires Node 20 or newer.
 Then check the code:
 
 ```bash
 git clone <repo-url>
 cd PoseDetection
 # run once with network access to fetch pre-commit hooks
-.codex/setup.sh
+./.codex/setup.sh   # Windows: scripts/setup.ps1
 make lint
 make test
 ```
@@ -32,6 +35,8 @@ make test
 If the network is unavailable pass `SKIP_PRECOMMIT=1` to the setup script.
 `pre-commit run` will then try to fetch hooks and may ask for GitHub
 credentials.
+If PowerShell is unavailable install Python 3.11 and Node 20 manually, then run
+`pip install -r requirements.txt` followed by `npm install`.
 
 The Python dependencies install `mediapipe==0.10.13`,
 `websockets==15.0.1` and `numpy==1.26.4`.
@@ -68,8 +73,9 @@ Dependabot reviews `requirements.txt`, `package.json` and
 
 ## Setup
 
-Run `.codex/setup.sh` after cloning to install Python 3.11 (set
+Run the provided setup script after cloning to install Python 3.11 (set
 `PYTHON_VERSION` to override) and Node 20 (set `NODE_VERSION` to change).
+On Windows use `scripts/setup.ps1`; other platforms use `.codex/setup.sh`.
 This installs `black` from `requirements.txt` so
 `make lint` works even when hooks are skipped. Tests rely on these packages,
 so always complete this step before running `make test`. The script is

--- a/TODO.md
+++ b/TODO.md
@@ -138,3 +138,5 @@
 - [x] Pin mypy version in requirements so `make typecheck` works offline.
 - [ ] Publish Docker image to a registry
 - [x] Upgrade pages workflow to `actions/upload-pages-artifact@v3`.
+- [x] Add PowerShell setup script for Windows and document manual setup
+      alternatives.

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,0 +1,52 @@
+# Windows setup script mirroring .codex/setup.sh
+Param(
+    [string]$PYTHON_VERSION = $env:PYTHON_VERSION ? $env:PYTHON_VERSION : '3.11',
+    [string]$NODE_VERSION = $env:NODE_VERSION ? $env:NODE_VERSION : '20'
+)
+
+$ProjectRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$PreCommitHome = $env:PRE_COMMIT_HOME
+if (-not $PreCommitHome) { $PreCommitHome = Join-Path $ProjectRoot '..' | Join-Path -ChildPath '.pre-commit-cache' }
+$env:PRE_COMMIT_HOME = $PreCommitHome
+New-Item -ItemType Directory -Force $PreCommitHome | Out-Null
+Set-Location (Join-Path $ProjectRoot '..')
+
+function Have-Python {
+    try { python --version | Select-String -Quiet $PYTHON_VERSION } catch { $false }
+}
+function Have-Node {
+    try { node --version | Select-String -Quiet "v$NODE_VERSION" } catch { $false }
+}
+
+if (-not (Have-Python)) {
+    if (Get-Command winget -ErrorAction SilentlyContinue) {
+        winget install --id "Python.Python.$PYTHON_VERSION" -e -h
+    } elseif (Get-Command choco -ErrorAction SilentlyContinue) {
+        choco install python --version $PYTHON_VERSION -y
+    } else {
+        Write-Host "Install Python $PYTHON_VERSION manually."
+    }
+}
+
+if (-not (Have-Node)) {
+    if (Get-Command winget -ErrorAction SilentlyContinue) {
+        winget install --id "OpenJS.NodeJS.$NODE_VERSION" -e -h
+    } elseif (Get-Command choco -ErrorAction SilentlyContinue) {
+        choco install nodejs --version $NODE_VERSION -y
+    } else {
+        Write-Host "Install Node.js $NODE_VERSION manually."
+    }
+}
+
+python -m pip install -r requirements.txt
+python -m pip install pre-commit
+if (Get-Command pyenv -ErrorAction SilentlyContinue) { pyenv rehash }
+
+if ((Test-Path .pre-commit-config.yaml) -and $env:SKIP_PRECOMMIT -ne '1') {
+    python -m pre_commit install --install-hooks --overwrite --config .pre-commit-config.yaml
+    python -m pre_commit install --install-hooks --overwrite
+    try { python -m pre_commit run --all-files } catch { Write-Host $_ }
+}
+
+npm install
+Write-Host "Setup complete"


### PR DESCRIPTION
## Summary
- add Windows `scripts/setup.ps1` that mirrors the bash setup
- document PowerShell script and manual fallback in README
- reference the new script in AGENTS guide
- record the change in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68791d97e3c48325afec9d42bb77d1ed