### PR TITLE
Switch PoseDetector to streaming mode

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1149,3 +1149,10 @@ errors and maintains coverage.
 - **Motivation / Decision**: ensure `make typecheck` works offline and update
   bootstrap docs.
 - **Next step**: publish Docker image to a registry.
+
+### 2025-07-17  PR #-1
+
+- **Summary**: set PoseDetector to dynamic mode and documented the improvement.
+- **Stage**: implementation
+- **Motivation / Decision**: lower latency using MediaPipe streaming mode.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -138,3 +138,4 @@
 - [x] Pin mypy version in requirements so `make typecheck` works offline.
 - [ ] Publish Docker image to a registry
 - [x] Upgrade pages workflow to `actions/upload-pages-artifact@v3`.
+- [x] Set `static_image_mode=False` in PoseDetector for better streaming performance.

--- a/backend/pose_detector.py
+++ b/backend/pose_detector.py
@@ -28,7 +28,8 @@ class PoseDetector:
     ]
 
     def __init__(self) -> None:
-        self._pose = mp.solutions.pose.Pose(model_complexity=1, static_image_mode=True)
+        # static_image_mode=False improves performance in video streams
+        self._pose = mp.solutions.pose.Pose(model_complexity=1, static_image_mode=False)
 
     def process(self, frame: np.ndarray) -> list[dict[str, float]]:
         """Return 17 keypoints as dicts with x, y and visibility."""

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,9 @@ Start the backend server with:
 python -m backend.server
 ```
 
+The pose detector uses `static_image_mode=False` for real-time
+performance with continuous frames.
+
 ## Frontend metrics panel
 
 The React frontend displays these metrics below the video feed. When

--- a/tests/backend/test_pose_detector.py
+++ b/tests/backend/test_pose_detector.py
@@ -85,3 +85,20 @@ def test_close(monkeypatch):
     det = pd.PoseDetector()
     det.close()
     assert getattr(fake, "closed", False) is True
+
+
+class InspectPose:
+    def __init__(self, *args, **kwargs) -> None:
+        InspectPose.kwargs = kwargs
+
+    def process(self, _frame):
+        return types.SimpleNamespace(pose_landmarks=None)
+
+    def close(self) -> None:
+        pass
+
+
+def test_init_sets_static_image_mode_false(monkeypatch):
+    monkeypatch.setattr(mp.solutions.pose, "Pose", InspectPose)
+    pd.PoseDetector()
+    assert InspectPose.kwargs.get("static_image_mode") is False


### PR DESCRIPTION
## Summary
- instantiate MediaPipe Pose in streaming mode
- check PoseDetector uses static_image_mode=False
- describe the performance tweak in docs
- record work in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68791d8e43fc8325accbce88148cfa5c