### PR TITLE
Add posture angle metric

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1149,3 +1149,10 @@ errors and maintains coverage.
 - **Motivation / Decision**: ensure `make typecheck` works offline and update
   bootstrap docs.
 - **Next step**: publish Docker image to a registry.
+
+### 2025-07-17  PR #147
+
+- **Summary**: added posture angle metric across backend and frontend.
+- **Stage**: implementation
+- **Motivation / Decision**: compute torso angle to display posture data.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ a dictionary with ``x``, ``y`` and ``visibility``. The keypoints are ordered as
 ``left_shoulder``, ``right_shoulder``, ``left_elbow``, ``right_elbow``,
 ``left_wrist``, ``right_wrist``, ``left_hip``, ``right_hip``, ``left_knee``,
 ``right_knee``, ``left_ankle`` and ``right_ankle``. The payload also includes
-simple analytics like knee angle, balance and a ``pose_class`` field
-indicating ``standing`` or ``sitting``.
+simple analytics like knee angle, balance, a posture angle and a ``pose_class``
+field indicating ``standing`` or ``sitting``.
 
 ## Development
 

--- a/TODO.md
+++ b/TODO.md
@@ -138,3 +138,4 @@
 - [x] Pin mypy version in requirements so `make typecheck` works offline.
 - [ ] Publish Docker image to a registry
 - [x] Upgrade pages workflow to `actions/upload-pages-artifact@v3`.
+- [x] Add posture angle metric in backend and frontend.

--- a/backend/analytics.py
+++ b/backend/analytics.py
@@ -106,6 +106,7 @@ def pose_classification(landmarks: Mapping[str, Point]) -> str:
 def extract_pose_metrics(landmarks: Mapping[str, Point]) -> Dict[str, float | str]:
     """Return analytics dictionary from pose landmarks."""
     knee_angle = float("nan")
+    posture_angle = float("nan")
     for side in ("left", "right"):
         try:
             knee_angle = calculate_angle(
@@ -113,15 +114,26 @@ def extract_pose_metrics(landmarks: Mapping[str, Point]) -> Dict[str, float | st
                 landmarks[f"{side}_knee"],
                 landmarks[f"{side}_ankle"],
             )
+            posture_angle = calculate_angle(
+                landmarks[f"{side}_shoulder"],
+                landmarks[f"{side}_hip"],
+                landmarks[f"{side}_knee"],
+            )
             break
         except KeyError:
             continue
         except ValueError:
             knee_angle = float("nan")
+            posture_angle = float("nan")
             break
     try:
         balance = balance_score(landmarks)
     except ValueError:
         balance = float("nan")
     pose = pose_classification(landmarks)
-    return {"knee_angle": knee_angle, "balance": balance, "pose_class": pose}
+    return {
+        "knee_angle": knee_angle,
+        "balance": balance,
+        "pose_class": pose,
+        "posture_angle": posture_angle,
+    }

--- a/frontend/src/__tests__/MetricsPanel.test.tsx
+++ b/frontend/src/__tests__/MetricsPanel.test.tsx
@@ -2,13 +2,20 @@ import { render, screen } from '@testing-library/react';
 import MetricsPanel from '../components/MetricsPanel';
 import '@testing-library/jest-dom';
 
-test('displays balance, pose and knee angle', () => {
+test('displays balance, pose, knee and posture angle', () => {
   render(
     <MetricsPanel
-      data={{ balance: 0.5, pose_class: 'standing', knee_angle: 45.5 }}
+      data={{
+        balance: 0.5,
+        pose_class: 'standing',
+        knee_angle: 45.5,
+        posture_angle: 30.0,
+      }}
     />,
   );
   expect(
-    screen.getByText(/Balance: 0\.50 Pose: standing Knee Angle: 45\.50°/),
+    screen.getByText(
+      /Balance: 0\.50 Pose: standing Knee Angle: 45\.50° Posture: 30\.00°/,
+    ),
   ).toBeInTheDocument();
 });

--- a/frontend/src/components/MetricsPanel.tsx
+++ b/frontend/src/components/MetricsPanel.tsx
@@ -1,14 +1,24 @@
+export interface PoseMetrics {
+  balance: number;
+  pose_class: string;
+  knee_angle: number;
+  posture_angle: number;
+  [key: string]: number | string;
+}
+
 interface MetricsPanelProps {
-  data?: Record<string, number | string>;
+  data?: PoseMetrics;
 }
 
 const MetricsPanel: React.FC<MetricsPanelProps> = ({ data }) => {
   const balance = Number(data?.balance ?? 0);
   const pose = data?.pose_class ?? '';
   const knee = Number(data?.knee_angle ?? 0);
+  const posture = Number(data?.posture_angle ?? 0);
   return (
     <div className="metrics-panel">
       Balance: {balance.toFixed(2)} Pose: {pose} Knee Angle: {knee.toFixed(2)}°
+      Posture: {posture.toFixed(2)}°
     </div>
   );
 };

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 import useWebSocket from '../hooks/useWebSocket';
 import { drawSkeleton, Point } from '../utils/poseDrawing';
-import MetricsPanel from './MetricsPanel';
+import MetricsPanel, { PoseMetrics } from './MetricsPanel';
 
 interface PoseData {
   landmarks: Point[];
-  metrics: Record<string, number | string>;
+  metrics: PoseMetrics;
 }
 
 const PoseViewer: React.FC = () => {

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -40,11 +40,13 @@ def test_extract_pose_metrics_missing_landmarks():
     metrics = extract_pose_metrics({})
     assert math.isnan(metrics["knee_angle"])
     assert math.isnan(metrics["balance"])
+    assert math.isnan(metrics["posture_angle"])
     assert metrics["pose_class"] == "unknown"
 
 
 def test_extract_pose_metrics_left_side():
     lms = {
+        "left_shoulder": {"x": 0.0, "y": -1.0},
         "left_hip": {"x": 0.0, "y": 0.0},
         "left_knee": {"x": 0.0, "y": 1.0},
         "left_ankle": {"x": 1.0, "y": 1.0},
@@ -53,11 +55,13 @@ def test_extract_pose_metrics_left_side():
     metrics = extract_pose_metrics(lms)
     assert not math.isnan(metrics["knee_angle"])
     assert not math.isnan(metrics["balance"])
+    assert not math.isnan(metrics["posture_angle"])
     assert metrics["pose_class"] in {"standing", "sitting", "unknown"}
 
 
 def test_extract_pose_metrics_right_side():
     lms = {
+        "right_shoulder": {"x": 1.0, "y": -1.0},
         "right_hip": {"x": 1.0, "y": 0.0},
         "right_knee": {"x": 1.0, "y": 1.0},
         "right_ankle": {"x": 0.0, "y": 1.0},
@@ -66,6 +70,7 @@ def test_extract_pose_metrics_right_side():
     metrics = extract_pose_metrics(lms)
     assert not math.isnan(metrics["knee_angle"])
     assert not math.isnan(metrics["balance"])
+    assert not math.isnan(metrics["posture_angle"])
     assert metrics["pose_class"] in {"standing", "sitting", "unknown"}
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,7 +13,7 @@ def test_build_payload_format():
     assert len(payload["landmarks"]) == 17
     assert payload["landmarks"][0]["x"] == 0.1
     metrics = payload["metrics"]
-    assert {"knee_angle", "balance", "pose_class"} <= metrics.keys()
+    assert {"knee_angle", "balance", "pose_class", "posture_angle"} <= metrics.keys()
 
 
 def test_names_match_landmarks():


### PR DESCRIPTION
## Summary
- compute posture angle via shoulder-hip-knee in analytics
- expose new `posture_angle` metric through the server payload
- type PoseMetrics and show posture angle in MetricsPanel
- extend backend/frontend tests for posture angle
- document the metric

## Testing
- `python3 -m pre_commit run --files NOTES.md README.md TODO.md backend/analytics.py frontend/src/__tests__/MetricsPanel.test.tsx frontend/src/components/MetricsPanel.tsx frontend/src/components/PoseViewer.tsx tests/test_analytics.py tests/test_server.py`
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68791d7b01048325af48ef375b7fa60d