### PR TITLE
Document enabling Pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.39 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.40 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -69,7 +69,9 @@ prevents GitHub prompts.
     `.github/workflows/ci.yml` (see § 4) so forks without secrets still pass.
 4. Pushes to `main` run `.github/workflows/pages.yml` which builds the Sphinx
    docs, uploads them using `actions/upload-pages-artifact@v3` and deploys them
-   to GitHub Pages when `GH_PAGES_TOKEN` is present.
+   to GitHub Pages when `GH_PAGES_TOKEN` is present. Enable Pages in the repo
+   settings with **GitHub Actions** as the source. `GH_PAGES_TOKEN` requires
+   `pages:write` and repo access.
 5. On the first PR, update README badges to point at your fork (owner/repo).
 6. `.codex/setup.sh` installs `pre-commit`, sets up the hooks and then runs
    `pre-commit run --all-files`. This may reformat files, so run the script

--- a/NOTES.md
+++ b/NOTES.md
@@ -1149,3 +1149,12 @@ errors and maintains coverage.
 - **Motivation / Decision**: ensure `make typecheck` works offline and update
   bootstrap docs.
 - **Next step**: publish Docker image to a registry.
+
+### 2025-07-17  PR #draft
+
+- **Summary**: clarified that Pages must be enabled with GitHub Actions as
+  source and the token needs `pages:write` and repo access.
+- **Stage**: documentation
+- **Motivation / Decision**: ensure maintainers configure Pages before expecting
+  deployments.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -143,8 +143,10 @@ make docs
 ```
 
 The output appears in `docs/_build/html`.
-Pushes to `main` trigger `.github/workflows/pages.yml` to build these docs and
-deploy them to GitHub Pages when the `GH_PAGES_TOKEN` secret is available.
+Pushes to `main` run `.github/workflows/pages.yml` to build the docs.
+When `GH_PAGES_TOKEN` is available the workflow deploys them to GitHub Pages.
+Enable Pages in the repo settings with **GitHub Actions** as the source before
+expecting deployments.
 
 ## License
 

--- a/TODO.md
+++ b/TODO.md
@@ -138,3 +138,5 @@
 - [x] Pin mypy version in requirements so `make typecheck` works offline.
 - [ ] Publish Docker image to a registry
 - [x] Upgrade pages workflow to `actions/upload-pages-artifact@v3`.
+- [ ] Enable GitHub Pages with **GitHub Actions** as the source before
+      expecting deployments.


### PR DESCRIPTION
## Summary
- update AGENTS.md to v1.40
- clarify in the bootstrap checklist how to enable Pages and token requirements
- mention enabling Pages in the docs section of README
- track new requirement in TODO
- record the change in NOTES

## Testing
- `make lint-docs`
- `pre-commit run --files AGENTS.md README.md NOTES.md TODO.md`

------
https://chatgpt.com/codex/tasks/task_e_68791d1368048325864f830b082fb88f