### PR TITLE
Fix PS5.1 setup script

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1221,3 +1221,10 @@ errors and maintains coverage.
 - **Stage**: documentation
 - **Motivation / Decision**: help users who lack `make` or run on Windows.
 - **Next step**: none.
+
+### 2025-07-17  PR #158
+
+- **Summary**: fixed setup.ps1 so PowerShell 5.1 accepts parameters.
+- **Stage**: implementation
+- **Motivation / Decision**: PS 5.1 lacks the ternary operator; changed to if/else.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO – Road‑map (last updated: 2025-07-18)
+# TODO – Road‑map (last updated: 2025-07-17)
 
 > *Record only high‑level milestones here; break micro‑tasks out into Issues.*
 > **When you finish a task, tick it and append a short NOTE entry
@@ -150,3 +150,4 @@
 - [x] Add PowerShell setup script for Windows and document manual setup
       alternatives.
 - [x] Document alternative wrappers and mention WSL/Docker for Windows users.
+- [x] Fix PowerShell setup script for compatibility with PowerShell 5.1.

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,8 +1,20 @@
 # Windows setup script mirroring .codex/setup.sh
 Param(
-    [string]$PYTHON_VERSION = $env:PYTHON_VERSION ? $env:PYTHON_VERSION : '3.11',
-    [string]$NODE_VERSION = $env:NODE_VERSION ? $env:NODE_VERSION : '20'
+    [string]$PYTHON_VERSION,
+    [string]$NODE_VERSION
 )
+
+if ($env:PYTHON_VERSION) {
+    $PYTHON_VERSION = $env:PYTHON_VERSION
+} elseif (-not $PYTHON_VERSION) {
+    $PYTHON_VERSION = '3.11'
+}
+
+if ($env:NODE_VERSION) {
+    $NODE_VERSION = $env:NODE_VERSION
+} elseif (-not $NODE_VERSION) {
+    $NODE_VERSION = '20'
+}
 
 $ProjectRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 $PreCommitHome = $env:PRE_COMMIT_HOME


### PR DESCRIPTION
## Summary
- make `scripts/setup.ps1` work with PowerShell 5.1 by using if/else
- document the update in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`
- `python3 -m pre_commit run --files scripts/setup.ps1`
- `make lint-docs`
- `pwsh -File scripts/setup.ps1 -PYTHON_VERSION 3.12 -NODE_VERSION 20`

PowerShell 5.1 was unavailable so its tests could not be executed.

------
https://chatgpt.com/codex/tasks/task_e_68792932a3308325b08a4080a049923a