### PR TITLE
Add websocket close control

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1228,3 +1228,12 @@ errors and maintains coverage.
 - **Stage**: implementation
 - **Motivation / Decision**: PS 5.1 lacks the ternary operator; changed to if/else.
 - **Next step**: none.
+
+### 2025-07-17  PR #159
+
+- **Summary**: added close() to useWebSocket and tests, stop button now closes
+  WebSocket and reconnection works; backend handles disconnect without errors.
+- **Stage**: implementation
+- **Motivation / Decision**: allow users to stop streaming cleanly and ensure
+  resources release on client disconnect.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ npm test
 ```
 
 The PoseViewer component shows the live webcam feed. The **Start Webcam**
-button toggles streaming on and off. It calls `setStreaming(!streaming)` in
+button toggles streaming on and off. Stopping the webcam also closes the
+WebSocket connection. It calls `setStreaming(!streaming)` in
 [`PoseViewer.tsx`](frontend/src/components/PoseViewer.tsx). A canvas overlay
 draws lines between keypoints to show the pose skeleton.
 The `useWebSocket` hook returns the latest pose data and a connection state

--- a/TODO.md
+++ b/TODO.md
@@ -151,3 +151,4 @@
       alternatives.
 - [x] Document alternative wrappers and mention WSL/Docker for Windows users.
 - [x] Fix PowerShell setup script for compatibility with PowerShell 5.1.
+- [x] Close WebSocket when stopping the webcam and reopen when restarted.

--- a/backend/server.py
+++ b/backend/server.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import cv2
-from fastapi import FastAPI, WebSocket
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.staticfiles import StaticFiles
 import asyncio
 
@@ -74,6 +74,8 @@ async def pose_endpoint(ws: WebSocket) -> None:
 
             payload = build_payload(points)
             await ws.send_text(json.dumps(payload))
+    except (WebSocketDisconnect, RuntimeError):
+        await ws.close()
     except Exception:
         await ws.close()
         raise

--- a/frontend/src/__tests__/useWebSocket.test.tsx
+++ b/frontend/src/__tests__/useWebSocket.test.tsx
@@ -106,3 +106,24 @@ test('valid messages clear previous error', () => {
   window.WebSocket = OriginalWebSocket;
 });
 
+test('close function sets status to closed', () => {
+  const ws = new MockWebSocket('ws://test');
+  const OriginalWebSocket = window.WebSocket;
+  // @ts-ignore
+  window.WebSocket = jest.fn(() => ws);
+
+  const { result } = renderHook(() => useWebSocket('/pose'));
+
+  act(() => {
+    ws.triggerOpen();
+  });
+  expect(result.current.status).toBe('open');
+
+  act(() => {
+    result.current.close();
+  });
+  expect(result.current.status).toBe('closed');
+
+  window.WebSocket = OriginalWebSocket;
+});
+

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -11,7 +11,10 @@ interface PoseData {
 const PoseViewer: React.FC = () => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const { poseData, status, error } = useWebSocket<PoseData>('/pose');
+  const [wsKey, setWsKey] = useState(0);
+  const { poseData, status, error, close } = useWebSocket<PoseData>(
+    `/pose?c=${wsKey}`,
+  );
   const [streaming, setStreaming] = useState(true);
   const streamRef = useRef<MediaStream | null>(null);
 
@@ -63,7 +66,17 @@ const PoseViewer: React.FC = () => {
       <MetricsPanel data={poseData?.metrics} />
       {error && <div className="ws-error">Error: {error}</div>}
       <div className="connection-status">Connection: {status}</div>
-      <button onClick={() => setStreaming((s) => !s)}>
+      <button
+        onClick={() => {
+          if (streaming) {
+            close();
+            setStreaming(false);
+          } else {
+            setWsKey((k) => k + 1);
+            setStreaming(true);
+          }
+        }}
+      >
         {streaming ? 'Stop Webcam' : 'Start Webcam'}
       </button>
     </div>

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -21,6 +21,10 @@ export default function useWebSocket<T>(
   const [status, setStatus] = useState<'connecting' | 'open' | 'closed' | 'error'>('connecting');
   const wsRef = useRef<WebSocket>();
 
+  function close() {
+    wsRef.current?.close();
+  }
+
   useEffect(() => {
     const url = resolveUrl(path, host, port);
     const ws = new WebSocket(url);
@@ -52,5 +56,5 @@ export default function useWebSocket<T>(
     };
   }, [path, host, port]);
 
-  return { poseData, status, error: errorMsg };
+  return { poseData, status, error: errorMsg, close };
 }


### PR DESCRIPTION
## Summary
- expose `close()` from `useWebSocket`
- reopen socket when restarting webcam in `PoseViewer`
- handle disconnects in `pose_endpoint`
- test websocket close flow
- document that stopping webcam closes the connection
- record progress in NOTES and TODO

## Testing
- `python3 -m pre_commit run --files NOTES.md README.md TODO.md backend/server.py frontend/src/__tests__/PoseViewer.test.tsx frontend/src/__tests__/useWebSocket.test.tsx frontend/src/components/PoseViewer.tsx frontend/src/hooks/useWebSocket.ts tests/test_server.py`
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68792f9086f08325bea7653be3b8fff4