### PR TITLE
Add PowerShell wrappers for make commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.40 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.41 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -86,6 +86,8 @@ prevents GitHub prompts.
    shims are picked up.
 10. A `Dockerfile` sets up Python 3.11 and Node 20. Build it with
    `docker build -t posedetect .` to run tests in a container.
+11. Windows users without `make` can run the wrapper scripts in
+    `scripts/windows/` (e.g. `lint.ps1`, `test.ps1`).
 
 ---
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1228,3 +1228,11 @@ errors and maintains coverage.
 - **Stage**: implementation
 - **Motivation / Decision**: PS 5.1 lacks the ternary operator; changed to if/else.
 - **Next step**: none.
+
+### 2025-07-17  PR #159
+
+- **Summary**: added PowerShell wrappers for Makefile commands.
+- **Stage**: implementation
+- **Motivation / Decision**: allow Windows users to run lint, tests and docs
+  without make.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ cd PoseDetection
 ./.codex/setup.sh   # Windows: scripts/setup.ps1
 make lint
 make test
+# Windows users without make can run:
+#   scripts/windows/lint.ps1
+#   scripts/windows/test.ps1
 ```
 
 If the network is unavailable pass `SKIP_PRECOMMIT=1` to the setup script.
@@ -64,6 +67,7 @@ Run `make typecheck-ts` to compile the frontend TypeScript.
 Run `make test` to execute the test-suite. Performance tests live in
 `tests/performance` and run automatically. Run them on their own with
 `pytest tests/performance`.
+Windows wrappers for these commands live in `scripts/windows/`.
 CI runs `make check-versions` whenever dependency files change to
 ensure pinned versions are valid.
 Pre-commit hooks are installed automatically by `.codex/setup.sh`,

--- a/TODO.md
+++ b/TODO.md
@@ -151,3 +151,4 @@
       alternatives.
 - [x] Document alternative wrappers and mention WSL/Docker for Windows users.
 - [x] Fix PowerShell setup script for compatibility with PowerShell 5.1.
+- [x] Provide PowerShell wrappers for Makefile commands.

--- a/scripts/windows/docs.ps1
+++ b/scripts/windows/docs.ps1
@@ -1,0 +1,13 @@
+# PowerShell wrapper for `make docs` building the Sphinx HTML docs.
+# Requires dependencies installed via scripts/setup.ps1.
+
+$ErrorActionPreference = 'Stop'
+
+Push-Location docs
+try {
+    ./make.bat html
+    $code = $LASTEXITCODE
+} finally {
+    Pop-Location
+}
+exit $code

--- a/scripts/windows/generate.ps1
+++ b/scripts/windows/generate.ps1
@@ -1,0 +1,8 @@
+# PowerShell wrapper for `make generate`.
+# Runs the code generator.
+# Requires dependencies installed via scripts/setup.ps1.
+
+$ErrorActionPreference = 'Stop'
+
+python scripts/generate.py
+exit $LASTEXITCODE

--- a/scripts/windows/lint.ps1
+++ b/scripts/windows/lint.ps1
@@ -1,0 +1,18 @@
+# PowerShell wrapper for `make lint`
+# Run markdownlint, black, ruff and repo checks.
+# Requires Node and Python packages installed via scripts/setup.ps1.
+# SKIP_PRECOMMIT can be set when running setup.ps1 to skip hook installation.
+
+$ErrorActionPreference = 'Stop'
+
+npx --yes markdownlint-cli '**/*.md' --ignore node_modules --ignore .pre-commit-cache --ignore frontend/dist --ignore docs/_build
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+black --check backend scripts tests docs
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+ruff check backend scripts tests
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+python scripts/repo_checks.py
+exit $LASTEXITCODE

--- a/scripts/windows/test.ps1
+++ b/scripts/windows/test.ps1
@@ -1,0 +1,19 @@
+# PowerShell wrapper for `make test`.
+# Runs pytest and frontend Jest tests when present.
+# Requires dependencies installed via scripts/setup.ps1.
+
+$ErrorActionPreference = 'Stop'
+
+if (Test-Path tests) {
+    python -m pytest --cov=backend --cov=frontend --cov-config=.coveragerc --cov-fail-under=80
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+} else {
+    Write-Host 'No tests yet'
+}
+
+if (Test-Path 'frontend/src/__tests__') {
+    npx --yes jest
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
+
+exit 0

--- a/scripts/windows/typecheck-ts.ps1
+++ b/scripts/windows/typecheck-ts.ps1
@@ -1,0 +1,7 @@
+# PowerShell wrapper for `make typecheck-ts` running the TypeScript compiler.
+# Requires Node packages installed via scripts/setup.ps1.
+
+$ErrorActionPreference = 'Stop'
+
+npx --yes tsc --noEmit -p frontend/tsconfig.json
+exit $LASTEXITCODE

--- a/scripts/windows/typecheck.ps1
+++ b/scripts/windows/typecheck.ps1
@@ -1,0 +1,7 @@
+# PowerShell wrapper for `make typecheck` running mypy.
+# Requires dependencies installed via scripts/setup.ps1.
+
+$ErrorActionPreference = 'Stop'
+
+mypy backend
+exit $LASTEXITCODE


### PR DESCRIPTION
## Summary
- add Windows scripts mirroring Makefile tasks
- document wrappers in AGENTS and README
- record the work in NOTES and TODO

## Testing
- `./.codex/setup.sh`
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687933310bd483259dea16b6aa18fcee