### PR TITLE
Add Windows CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,39 @@ jobs:
       - run: make typecheck
       - run: make typecheck-ts
       - run: make test
+
+  test-windows:
+    needs: [changes]
+    if: needs.changes.outputs.md_only != 'true'
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python: ['3.11', '3.12']
+        node: ['20']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Bootstrap
+        shell: pwsh
+        run: |
+          $env:PYTHON_VERSION='${{ matrix.python }}'
+          $env:NODE_VERSION='${{ matrix.node }}'
+          $env:SKIP_PRECOMMIT='1'
+          ./scripts/setup.ps1
+      - name: Lint
+        shell: pwsh
+        run: ./scripts/windows/lint.ps1
+      - name: Typecheck
+        shell: pwsh
+        run: ./scripts/windows/typecheck.ps1
+      - name: Test
+        shell: pwsh
+        run: ./scripts/windows/test.ps1
+      - name: Docs
+        shell: pwsh
+        run: ./scripts/windows/docs.ps1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.40 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.41 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -247,6 +247,9 @@ jobs:
 - **Code changes** run full lint + tests (`test`) and `actionlint`.
 - Add job matrices or deployments later—guardrails above already catch the 90 %
   most common issues.
+- A Windows job (`test-windows`) runs on `windows-latest` and calls the
+  PowerShell scripts in `scripts/windows` for linting, type checking,
+  testing and docs build.
 
 ---
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1228,3 +1228,11 @@ errors and maintains coverage.
 - **Stage**: implementation
 - **Motivation / Decision**: PS 5.1 lacks the ternary operator; changed to if/else.
 - **Next step**: none.
+
+### 2025-07-17  PR #159
+
+- **Summary**: added Windows job to CI with PowerShell scripts for linting, type
+  checks, tests and docs.
+- **Stage**: implementation
+- **Motivation / Decision**: ensure cross-platform verification using Windows runners.
+- **Next step**: monitor for CI failures on Windows.

--- a/TODO.md
+++ b/TODO.md
@@ -151,3 +151,4 @@
       alternatives.
 - [x] Document alternative wrappers and mention WSL/Docker for Windows users.
 - [x] Fix PowerShell setup script for compatibility with PowerShell 5.1.
+- [x] Add Windows CI job using PowerShell scripts.

--- a/scripts/windows/docs.ps1
+++ b/scripts/windows/docs.ps1
@@ -1,0 +1,3 @@
+$ErrorActionPreference = 'Stop'
+
+python -m sphinx -M html docs/source docs/_build

--- a/scripts/windows/lint.ps1
+++ b/scripts/windows/lint.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = 'Stop'
+
+npx --yes markdownlint-cli '**/*.md' --ignore node_modules --ignore .pre-commit-cache --ignore frontend/dist --ignore docs/_build
+black --check backend scripts tests docs
+ruff check backend scripts tests
+python scripts/repo_checks.py

--- a/scripts/windows/test.ps1
+++ b/scripts/windows/test.ps1
@@ -1,0 +1,11 @@
+$ErrorActionPreference = 'Stop'
+
+if (Test-Path 'tests') {
+    python -m pytest --cov=backend --cov=frontend --cov-config=.coveragerc --cov-fail-under=80
+} else {
+    Write-Host 'No tests yet'
+}
+
+if (Test-Path 'frontend/src/__tests__') {
+    npx --yes jest
+}

--- a/scripts/windows/typecheck.ps1
+++ b/scripts/windows/typecheck.ps1
@@ -1,0 +1,4 @@
+$ErrorActionPreference = 'Stop'
+
+mypy backend
+npx --yes tsc --noEmit -p frontend/tsconfig.json


### PR DESCRIPTION
## Summary
- run CI on Windows via PowerShell scripts
- mention the new `test-windows` job in the contributor guide
- log the change
- keep TODO up to date

## Testing
- `make lint-docs`
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6879333c9f3883258c054eada3b8e672