### PR TITLE
Add pymake.py helper

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1228,3 +1228,10 @@ errors and maintains coverage.
 - **Stage**: implementation
 - **Motivation / Decision**: PS 5.1 lacks the ternary operator; changed to if/else.
 - **Next step**: none.
+
+### 2025-07-17  PR TBD
+
+- **Summary**: added `pymake.py` cross-platform wrapper and updated README.
+- **Stage**: implementation
+- **Motivation / Decision**: simplify running Make targets on Windows.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ Follow these steps to run the backend from Visual Studio:
 
 Install Node separately to build the React frontend with `npm run build`.
 
-If `make` does not work on your platform you can create npm scripts or a
-small Python wrapper that call `make lint` and `make test`. Windows users may
-prefer running the project in WSL or Docker when shell commands fail.
+If `make` does not work on your platform run `pymake.py <command>` instead.
+It dispatches to the same targets. Windows users may prefer WSL or Docker when
+shell commands fail.
 
 ## Frontend
 

--- a/TODO.md
+++ b/TODO.md
@@ -151,3 +151,4 @@
       alternatives.
 - [x] Document alternative wrappers and mention WSL/Docker for Windows users.
 - [x] Fix PowerShell setup script for compatibility with PowerShell 5.1.
+- [x] Provide cross-platform `pymake.py` wrapper for Make targets.

--- a/pymake.py
+++ b/pymake.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Cross-platform dispatcher for Make targets.
+
+Run ``make`` on Unix systems or a PowerShell script on Windows. The script
+expects one command argument such as ``lint`` or ``typecheck``. It prints a
+list of available commands when called without arguments or with an
+unknown command.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+COMMANDS = {
+    "lint",
+    "lint-docs",
+    "test",
+    "generate",
+    "docs",
+    "typecheck",
+    "typecheck-ts",
+    "update-todo-date",
+    "check-versions",
+}
+
+
+def _print_usage() -> None:
+    cmds = ", ".join(sorted(COMMANDS))
+    print(f"Usage: {Path(__file__).name} <command>")
+    print(f"Available commands: {cmds}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    if len(args) != 1 or args[0] not in COMMANDS:
+        _print_usage()
+        return 1
+    command = args[0]
+
+    if os.name == "nt":
+        script = Path("scripts") / f"{command}.ps1"
+        if not script.is_file():
+            print(f"error: missing script {script}", file=sys.stderr)
+            return 1
+        cmd = [
+            "powershell",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(script),
+        ]
+    else:
+        cmd = ["make", command]
+
+    return subprocess.call(cmd)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `pymake.py` for running Make targets on Windows
- mention wrapper in README
- log the change in NOTES and TODO

## Testing
- `make lint-docs`
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`
- `python -m pre_commit run --files pymake.py README.md TODO.md NOTES.md`

------
https://chatgpt.com/codex/tasks/task_e_6879333b3b3c8325bddb1c30042bef2a