### PR TITLE
Add Windows usage instructions

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1228,3 +1228,12 @@ errors and maintains coverage.
 - **Stage**: implementation
 - **Motivation / Decision**: PS 5.1 lacks the ternary operator; changed to if/else.
 - **Next step**: none.
+
+### 2025-07-17  PR #159
+
+- **Summary**: added Windows usage section and PowerShell scripts mirroring
+  Makefile commands.
+- **Stage**: documentation
+- **Motivation / Decision**: help Windows users run lint and tests without
+  `make`.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,24 @@ Sample frames for the performance test live in `tests/data/`.
 Placeholder images and a `labels.json` file are already present.
 The pose accuracy test skips unless you replace them with real frames.
 
+## Windows usage
+
+Run `scripts/setup.ps1` to install Python, Node and pre-commit hooks. Each
+Makefile target has a PowerShell wrapper so you do not need `make`. For
+example run `./scripts/lint.ps1` instead of `make lint`.
+
+| Makefile target       | PowerShell script           |
+| --------------------- | --------------------------- |
+| `make lint`           | `scripts/lint.ps1`          |
+| `make lint-docs`      | `scripts/lint-docs.ps1`     |
+| `make test`           | `scripts/test.ps1`          |
+| `make generate`       | `scripts/generate.ps1`      |
+| `make typecheck`      | `scripts/typecheck.ps1`     |
+| `make typecheck-ts`   | `scripts/typecheck-ts.ps1`  |
+| `make update-todo-date` | `scripts/update-todo-date.ps1` |
+| `make check-versions` | `scripts/check-versions.ps1`|
+| `make docs`           | `scripts/docs.ps1`          |
+
 ### Backend server
 
 Run `python -m backend.server` to launch the FastAPI server. The `/pose`

--- a/TODO.md
+++ b/TODO.md
@@ -151,3 +151,5 @@
       alternatives.
 - [x] Document alternative wrappers and mention WSL/Docker for Windows users.
 - [x] Fix PowerShell setup script for compatibility with PowerShell 5.1.
+- [x] Add PowerShell wrappers for Makefile targets so Windows users can run
+      lint and tests without `make`.

--- a/scripts/check-versions.ps1
+++ b/scripts/check-versions.ps1
@@ -1,0 +1,1 @@
+python scripts/check_versions.py

--- a/scripts/docs.ps1
+++ b/scripts/docs.ps1
@@ -1,0 +1,3 @@
+pushd docs
+make html
+popd

--- a/scripts/generate.ps1
+++ b/scripts/generate.ps1
@@ -1,0 +1,1 @@
+python scripts/generate.py

--- a/scripts/lint-docs.ps1
+++ b/scripts/lint-docs.ps1
@@ -1,0 +1,2 @@
+npx --yes markdownlint-cli '**/*.md'
+grep -R --line-number -E '<{7}|={7}|>{7}' --exclude=ci.yml --exclude-dir=node_modules --exclude-dir=.pre-commit-cache --exclude-dir=frontend/dist --exclude-dir=docs/_build . && exit 1 || Write-Host "No conflict markers"

--- a/scripts/lint.ps1
+++ b/scripts/lint.ps1
@@ -1,0 +1,4 @@
+npx --yes markdownlint-cli '**/*.md' --ignore node_modules --ignore .pre-commit-cache --ignore frontend/dist --ignore docs/_build
+black --check backend scripts tests docs
+ruff check backend scripts tests
+python scripts/repo_checks.py

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -1,0 +1,8 @@
+if (Test-Path tests) {
+    python -m pytest --cov=backend --cov=frontend --cov-config=.coveragerc --cov-fail-under=80
+} else {
+    Write-Host "No tests yet"
+}
+if (Test-Path frontend/src/__tests__) {
+    npx --yes jest
+}

--- a/scripts/typecheck-ts.ps1
+++ b/scripts/typecheck-ts.ps1
@@ -1,0 +1,1 @@
+npx --yes tsc --noEmit -p frontend/tsconfig.json

--- a/scripts/typecheck.ps1
+++ b/scripts/typecheck.ps1
@@ -1,0 +1,1 @@
+mypy backend

--- a/scripts/update-todo-date.ps1
+++ b/scripts/update-todo-date.ps1
@@ -1,0 +1,1 @@
+python scripts/update_todo_date.py


### PR DESCRIPTION
## Summary
- document Windows usage
- show PowerShell scripts for lint, test and docs
- map each Makefile target to its `.ps1` wrapper
- add tasks and notes about the new scripts

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687933381b9c83259787a9a23b0a6b62