### PR TITLE
Implement dynamic canvas sizing

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1250,7 +1250,6 @@ errors and maintains coverage.
 - **Stage**: implementation
 - **Motivation / Decision**: simplify running Make targets on Windows.
 
-
 ### 2025-07-17  PR #162
 
 - **Summary**: added PowerShell wrappers for Makefile commands.
@@ -1265,4 +1264,13 @@ errors and maintains coverage.
 - **Stage**: implementation
 - **Motivation / Decision**: allow users to stop streaming cleanly and ensure
   resources release on client disconnect.
+- **Next step**: none.
+
+### 2025-07-17  PR #164
+
+- **Summary**: canvas now resizes to the webcam video and tests cover the
+  behaviour. Added README note and updated TODO.
+- **Stage**: implementation
+- **Motivation / Decision**: ensure overlay matches video resolution when the
+  stream starts.
 - **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ If `make` does not work on your platform run `pymake.py <command>` instead.
 It dispatches to the same targets. Windows users may prefer WSL or Docker when
 shell commands fail.
 
-
 ## Frontend
 
 The `frontend` folder contains a small React app. Build it and run its tests:
@@ -133,7 +132,9 @@ The PoseViewer component shows the live webcam feed. The **Start Webcam**
 button toggles streaming on and off. Stopping the webcam also closes the
 WebSocket connection. It calls `setStreaming(!streaming)` in
 [`PoseViewer.tsx`](frontend/src/components/PoseViewer.tsx). A canvas overlay
-draws lines between keypoints to show the pose skeleton.
+draws lines between keypoints to show the pose skeleton. The canvas size is
+set from the video's `loadedmetadata` event so it matches the actual webcam
+resolution.
 The `useWebSocket` hook returns the latest pose data and a connection state
 (`connecting`, `open`, `closed` or `error`). PoseViewer displays this state so
 you know if the backend is reachable. The hook accepts optional `host` and

--- a/TODO.md
+++ b/TODO.md
@@ -155,3 +155,4 @@
 - [x] Provide cross-platform `pymake.py` wrapper for Make targets.
 - [x] Provide PowerShell wrappers for Makefile commands.
 - [x] Close WebSocket when stopping the webcam and reopen when restarted.
+- [x] Dynamically size canvas to video dimensions in PoseViewer.

--- a/frontend/src/__tests__/PoseViewer.test.tsx
+++ b/frontend/src/__tests__/PoseViewer.test.tsx
@@ -36,6 +36,24 @@ test('assigns webcam stream to video element', async () => {
   expect(getUserMedia).toHaveBeenCalled();
 });
 
+test('canvas matches video dimensions after metadata loads', async () => {
+  const { stream } = mockMedia();
+  const PoseViewer = require('../components/PoseViewer').default;
+  const { container } = render(<PoseViewer />);
+  const video = container.querySelector('video') as HTMLVideoElement;
+  const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+  await waitFor(() => {
+    expect(video.srcObject).toBe(stream);
+  });
+  Object.defineProperty(video, 'videoWidth', { value: 320 });
+  Object.defineProperty(video, 'videoHeight', { value: 240 });
+  fireEvent(video, new Event('loadedmetadata'));
+  await waitFor(() => {
+    expect(canvas.width).toBe(320);
+    expect(canvas.height).toBe(240);
+  });
+});
+
 test('toggle button stops and starts the webcam', async () => {
   const { stream, getUserMedia } = mockMedia();
   const PoseViewer = require('../components/PoseViewer').default;

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -18,6 +18,13 @@ const PoseViewer: React.FC = () => {
   const [streaming, setStreaming] = useState(true);
   const [cameraError, setCameraError] = useState<string | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
+  const resizeCanvas = () => {
+    const video = videoRef.current;
+    const canvas = canvasRef.current;
+    if (!video || !canvas) return;
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+  };
 
   useEffect(() => {
     const video = videoRef.current;
@@ -34,6 +41,7 @@ const PoseViewer: React.FC = () => {
           }
           video.srcObject = stream;
           streamRef.current = stream;
+          video.addEventListener('loadedmetadata', resizeCanvas, { once: true });
         })
         .catch(() => {
           setCameraError('Webcam access denied');
@@ -46,6 +54,7 @@ const PoseViewer: React.FC = () => {
     }
     return () => {
       cancel = true;
+      video.removeEventListener('loadedmetadata', resizeCanvas);
       if (streamRef.current) {
         streamRef.current.getTracks().forEach((t) => t.stop());
         video.srcObject = null;
@@ -66,7 +75,7 @@ const PoseViewer: React.FC = () => {
   return (
     <div className="pose-container">
       <video ref={videoRef} autoPlay muted />
-      <canvas ref={canvasRef} width={640} height={480} />
+      <canvas ref={canvasRef} />
       <MetricsPanel data={poseData?.metrics} />
       {error && <div className="ws-error">Error: {error}</div>}
       {cameraError && (


### PR DESCRIPTION
## Summary
- resize canvas to match video once the webcam stream metadata loads
- remove hard-coded canvas size
- document canvas sizing in README
- test that video and canvas sizes match
- check off TODO item
- log the change in NOTES

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687938765fbc8325b82ab41eb012ca8a