### PR TITLE
Add PowerShell wrappers for additional tasks

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1274,3 +1274,11 @@ errors and maintains coverage.
 - **Motivation / Decision**: ensure overlay matches video resolution when the
   stream starts.
 - **Next step**: none.
+
+### 2025-07-18  PR #165
+
+- **Summary**: added PowerShell wrappers for generate, lint-docs,
+update-todo-date and check-versions via npm scripts.
+- **Stage**: implementation
+- **Motivation / Decision**: allow Windows users to run all Make tasks.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ field indicating ``standing`` or ``sitting``.
 
 Run `make lint` to check Markdown and Python code style (ruff).
 On Windows you can run `npm run win:lint` instead. Similar wrappers exist for
-`typecheck`, `typecheck-ts`, `test` and `docs`.
+`typecheck`, `typecheck-ts`, `test`, `docs`, `generate`, `lint-docs`,
+`update-todo-date` and `check-versions`.
 Run `make typecheck` to check Python types with mypy.
 Run `make typecheck-ts` to compile the frontend TypeScript.
 Run `make test` to execute the test-suite. Performance tests live in
@@ -112,7 +113,7 @@ Follow these steps to run the backend from Visual Studio:
 Install Node separately to build the React frontend with `npm run build`.
 
 If `make` does not work on your platform use the provided PowerShell wrappers
-with `npm run win:lint` and `npm run win:test`. Windows users may still prefer
+via `npm run win:<target>` for any Make command. Windows users may still prefer
 WSL or Docker when shell commands fail.
 
 If `make` does not work on your platform run `pymake.py <command>` instead.

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO – Road‑map (last updated: 2025-07-17)
+# TODO – Road‑map (last updated: 2025-07-18)
 
 > *Record only high‑level milestones here; break micro‑tasks out into Issues.*
 > **When you finish a task, tick it and append a short NOTE entry

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "win:typecheck": "powershell -ExecutionPolicy Bypass -File scripts/typecheck.ps1",
     "win:typecheck-ts": "powershell -ExecutionPolicy Bypass -File scripts/typecheck-ts.ps1",
     "win:test": "powershell -ExecutionPolicy Bypass -File scripts/test.ps1",
-    "win:docs": "powershell -ExecutionPolicy Bypass -File scripts/docs.ps1"
+    "win:docs": "powershell -ExecutionPolicy Bypass -File scripts/docs.ps1",
+    "win:generate": "powershell -ExecutionPolicy Bypass -File scripts/generate.ps1",
+    "win:lint-docs": "powershell -ExecutionPolicy Bypass -File scripts/lint-docs.ps1",
+    "win:update-todo-date": "powershell -ExecutionPolicy Bypass -File scripts/update_todo_date.ps1",
+    "win:check-versions": "powershell -ExecutionPolicy Bypass -File scripts/check_versions.ps1"
   },
   "dependencies": {
     "react": "18.2.0",

--- a/scripts/check_versions.ps1
+++ b/scripts/check_versions.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = 'Stop'
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location (Join-Path $scriptDir '..')
+
+python scripts/check_versions.py
+exit $LASTEXITCODE

--- a/scripts/generate.ps1
+++ b/scripts/generate.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = 'Stop'
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location (Join-Path $scriptDir '..')
+
+python scripts/generate.py
+exit $LASTEXITCODE

--- a/scripts/lint-docs.ps1
+++ b/scripts/lint-docs.ps1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = 'Stop'
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location (Join-Path $scriptDir '..')
+
+npx --yes markdownlint-cli '**/*.md'
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+grep -R --line-number -E '<{7}|={7}|>{7}' `
+  --exclude=ci.yml `
+  --exclude-dir=node_modules `
+  --exclude-dir=.pre-commit-cache `
+  --exclude-dir=frontend/dist `
+  --exclude-dir=docs/_build `
+  . `
+  && exit 1 `
+  || Write-Host 'No conflict markers'
+exit $LASTEXITCODE

--- a/scripts/update_todo_date.ps1
+++ b/scripts/update_todo_date.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = 'Stop'
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location (Join-Path $scriptDir '..')
+
+python scripts/update_todo_date.py
+exit $LASTEXITCODE


### PR DESCRIPTION
## Summary
- add PowerShell scripts for `generate`, `lint-docs`, `update_todo-date` and `check-versions`
- expose the new scripts via npm `win:*` entries
- document Windows wrappers in README
- record the update in NOTES
- refresh TODO date

## Testing
- `make lint-docs`
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`
- `make check-versions`


------
https://chatgpt.com/codex/tasks/task_e_6879fe69d05883259b8783dd3b6d8942