### PR TITLE
Fix PowerShell wrappers failing early

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1305,3 +1305,10 @@ TODO logs the task.
 - **Stage**: implementation
 - **Motivation / Decision**: simplify wrapper usage and avoid duplicate scripts.
 - **Next step**: none.
+
+### 2025-07-18  PR #Y
+
+- **Summary**: PowerShell wrapper scripts now exit if any external command fails.
+- **Stage**: implementation
+- **Motivation / Decision**: let Windows CI fail when lint or tests fail.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -160,3 +160,4 @@
 - [x] Style pose container overlay to align video and canvas.
 - [x] Move PowerShell wrappers into `scripts/` and remove the
       `scripts/windows/` folder.
+- [x] Ensure PowerShell wrapper scripts exit when commands fail.

--- a/scripts/docs.ps1
+++ b/scripts/docs.ps1
@@ -3,3 +3,4 @@ $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 Set-Location (Join-Path $scriptDir '..')
 
 sphinx-build -b html docs/source docs/_build/html
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/scripts/lint.ps1
+++ b/scripts/lint.ps1
@@ -3,6 +3,10 @@ $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 Set-Location (Join-Path $scriptDir '..')
 
 npx --yes markdownlint-cli '**/*.md' --ignore node_modules --ignore .pre-commit-cache --ignore frontend/dist --ignore docs/_build
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 black --check backend scripts tests docs
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 ruff check backend scripts tests
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 python scripts/repo_checks.py
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -4,9 +4,11 @@ Set-Location (Join-Path $scriptDir '..')
 
 if (Test-Path 'tests') {
     python -m pytest --cov=backend --cov=frontend --cov-config=.coveragerc --cov-fail-under=80
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 } else {
     Write-Host 'No tests yet'
 }
 if (Test-Path 'frontend/src/__tests__') {
     npx --yes jest
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 }

--- a/scripts/typecheck-ts.ps1
+++ b/scripts/typecheck-ts.ps1
@@ -3,3 +3,4 @@ $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 Set-Location (Join-Path $scriptDir '..')
 
 npx --yes tsc --noEmit -p frontend/tsconfig.json
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/scripts/typecheck.ps1
+++ b/scripts/typecheck.ps1
@@ -3,3 +3,4 @@ $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 Set-Location (Join-Path $scriptDir '..')
 
 mypy backend
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }


### PR DESCRIPTION
## Summary
- ensure our Windows wrapper scripts exit when any command fails
- track this improvement in TODO and NOTES

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687a0be2a78083258e4703eafbc2e6ab