### PR TITLE
Add tests for pymake and PowerShell scripts

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1305,3 +1305,12 @@ TODO logs the task.
 - **Stage**: implementation
 - **Motivation / Decision**: simplify wrapper usage and avoid duplicate scripts.
 - **Next step**: none.
+
+### 2025-07-18  PR #X2
+
+- **Summary**: added tests for `pymake` and PowerShell wrappers to verify failure
+  exit codes.
+- **Stage**: testing
+- **Motivation / Decision**: ensure cross-platform wrappers behave correctly and
+  increase coverage.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -160,3 +160,4 @@
 - [x] Style pose container overlay to align video and canvas.
 - [x] Move PowerShell wrappers into `scripts/` and remove the
       `scripts/windows/` folder.
+- [x] Add tests for `pymake` and PowerShell wrappers.

--- a/tests/test_powershell_wrappers.py
+++ b/tests/test_powershell_wrappers.py
@@ -1,0 +1,51 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+WRAPPERS = [
+    ("check_versions.ps1", "python"),
+    ("docs.ps1", "sphinx-build"),
+    ("generate.ps1", "python"),
+    ("lint-docs.ps1", "npx"),
+    ("lint.ps1", "npx"),
+    ("test.ps1", "python"),
+    ("typecheck-ts.ps1", "npx"),
+    ("typecheck.ps1", "mypy"),
+    ("update_todo_date.ps1", "python"),
+]
+
+
+def _powershell_exe() -> str | None:
+    return shutil.which("pwsh") or shutil.which("powershell")
+
+
+@pytest.mark.skipif(_powershell_exe() is None, reason="PowerShell not installed")
+@pytest.mark.parametrize("script,cmd", WRAPPERS)
+def test_wrapper_exits_nonzero_on_failure(tmp_path, script: str, cmd: str) -> None:
+    exe = _powershell_exe()
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    stub = stub_dir / cmd
+    stub.write_text("#!/bin/sh\nexit 1\n")
+    stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{stub_dir}{os.pathsep}{env['PATH']}"
+
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "scripts" / script
+    result = subprocess.run(
+        [
+            exe,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(script_path),
+        ],
+        env=env,
+    )
+    assert result.returncode != 0

--- a/tests/test_pymake.py
+++ b/tests/test_pymake.py
@@ -1,0 +1,47 @@
+import subprocess
+import types
+from pathlib import Path
+
+import pymake
+
+
+def test_pymake_builds_make_command(monkeypatch):
+    calls = []
+
+    def fake_call(cmd):
+        calls.append(cmd)
+        return 0
+
+    monkeypatch.setattr(pymake, "os", types.SimpleNamespace(name="posix"))
+    monkeypatch.setattr(subprocess, "call", fake_call)
+    ret = pymake.main(["lint"])
+    assert ret == 0
+    assert calls == [["make", "lint"]]
+
+
+def test_pymake_builds_powershell_command(tmp_path, monkeypatch):
+    script_dir = tmp_path / "scripts"
+    script_dir.mkdir()
+    script_path = script_dir / "lint.ps1"
+    script_path.write_text("")
+    monkeypatch.chdir(tmp_path)
+
+    calls = []
+
+    def fake_call(cmd):
+        calls.append(cmd)
+        return 0
+
+    monkeypatch.setattr(pymake, "os", types.SimpleNamespace(name="nt"))
+    monkeypatch.setattr(subprocess, "call", fake_call)
+    ret = pymake.main(["lint"])
+    expected = [
+        "powershell",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        str(Path("scripts") / "lint.ps1"),
+    ]
+    assert ret == 0
+    assert calls == [expected]


### PR DESCRIPTION
## Summary
- test pymake.main builds the right subprocess command
- ensure PowerShell wrappers fail when their commands fail
- note the new coverage in NOTES
- log completion in TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687a0be8b760832596e50b15f3d95fb7