### PR TITLE
Fix pymake script path lookup

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1326,3 +1326,11 @@ TODO logs the task.
 - **Stage**: documentation
 - **Motivation / Decision**: help Windows users find the equivalent commands quickly.
 - **Next step**: none.
+
+-### 2025-07-20  PR #X172
+
+- **Summary**: adjusted pymake to find PowerShell scripts relative to its file
+  and added test for subdirectory usage.
+- **Stage**: implementation
+- **Motivation / Decision**: ensure wrapper works from any path per request.
+- **Next step**: none.

--- a/pymake.py
+++ b/pymake.py
@@ -40,7 +40,8 @@ def main(argv: list[str] | None = None) -> int:
     command = args[0]
 
     if os.name == "nt":
-        script = Path("scripts") / f"{command}.ps1"
+        script_dir = Path(__file__).resolve().parent / "scripts"
+        script = script_dir / f"{command}.ps1"
         if not script.is_file():
             print(f"error: missing script {script}", file=sys.stderr)
             return 1

--- a/tests/test_pymake.py
+++ b/tests/test_pymake.py
@@ -1,6 +1,5 @@
 import subprocess
 import types
-from pathlib import Path
 
 import pymake
 
@@ -25,6 +24,7 @@ def test_pymake_builds_powershell_command(tmp_path, monkeypatch):
     script_path = script_dir / "lint.ps1"
     script_path.write_text("")
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(pymake, "__file__", str(tmp_path / "pymake.py"))
 
     calls = []
 
@@ -41,7 +41,39 @@ def test_pymake_builds_powershell_command(tmp_path, monkeypatch):
         "-ExecutionPolicy",
         "Bypass",
         "-File",
-        str(Path("scripts") / "lint.ps1"),
+        str(script_path),
+    ]
+    assert ret == 0
+    assert calls == [expected]
+
+
+def test_pymake_works_from_subdirectory(tmp_path, monkeypatch):
+    root = tmp_path / "project"
+    script_dir = root / "scripts"
+    script_dir.mkdir(parents=True)
+    script_path = script_dir / "lint.ps1"
+    script_path.write_text("")
+    (root / "subdir").mkdir()
+
+    monkeypatch.chdir(root / "subdir")
+    monkeypatch.setattr(pymake, "__file__", str(root / "pymake.py"))
+
+    calls = []
+
+    def fake_call(cmd):
+        calls.append(cmd)
+        return 0
+
+    monkeypatch.setattr(pymake, "os", types.SimpleNamespace(name="nt"))
+    monkeypatch.setattr(subprocess, "call", fake_call)
+    ret = pymake.main(["lint"])
+    expected = [
+        "powershell",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        str(script_path),
     ]
     assert ret == 0
     assert calls == [expected]


### PR DESCRIPTION
## Summary
- resolve PowerShell script path using `Path(__file__)`
- test running pymake from a subdirectory
- note new behaviour in history

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687a11adf04c8325b6a6599acf5e785d