### PR TITLE
Fix PowerShell wrapper test stubs

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1334,6 +1334,7 @@ TODO logs the task.
 - **Motivation / Decision**: help contributors run Make targets on any OS.
 
 ### 2025-07-18  PR #173
+
 - **Summary**: pymake now checks for pwsh before powershell; tests updated.
 - **Stage**: implementation
 - **Motivation / Decision**: improve Windows compatibility.
@@ -1344,4 +1345,11 @@ TODO logs the task.
   and added test for subdirectory usage.
 - **Stage**: implementation
 - **Motivation / Decision**: ensure wrapper works from any path per request.
+- **Next step**: none.
+
+### 2025-07-21  PR #175
+
+- **Summary**: tests now use cmd stubs for Windows PowerShell wrappers.
+- **Stage**: testing
+- **Motivation / Decision**: ensure wrapper failure detection on Windows.
 - **Next step**: none.

--- a/tests/test_powershell_wrappers.py
+++ b/tests/test_powershell_wrappers.py
@@ -28,12 +28,18 @@ def test_wrapper_exits_nonzero_on_failure(tmp_path, script: str, cmd: str) -> No
     exe = _powershell_exe()
     stub_dir = tmp_path / "bin"
     stub_dir.mkdir()
+    # Create a cross-platform stub so wrappers fail regardless of PATHEXT
     stub = stub_dir / cmd
     stub.write_text("#!/bin/sh\nexit 1\n")
     stub.chmod(0o755)
 
+    win_stub = stub_dir / f"{cmd}.cmd"
+    win_stub.write_text("@echo off\r\nexit /b 1\r\n")
+    win_stub.chmod(0o755)
+
     env = os.environ.copy()
     env["PATH"] = f"{stub_dir}{os.pathsep}{env['PATH']}"
+    env["PATHEXT"] = f".CMD{os.pathsep}{env.get('PATHEXT', '')}"
 
     repo_root = Path(__file__).resolve().parents[1]
     script_path = repo_root / "scripts" / script

--- a/tests/test_pymake.py
+++ b/tests/test_pymake.py
@@ -1,5 +1,6 @@
 import subprocess
 import types
+from pathlib import Path
 
 import pymake
 
@@ -49,7 +50,7 @@ def test_pymake_prefers_pwsh(tmp_path, monkeypatch):
         "-ExecutionPolicy",
         "Bypass",
         "-File",
-        str(Path("scripts") / "lint.ps1"),
+        str(tmp_path / "scripts" / "lint.ps1"),
     ]
     assert ret == 0
     assert calls == [expected]
@@ -69,13 +70,14 @@ def test_pymake_falls_back_to_powershell(tmp_path, monkeypatch):
     monkeypatch.setattr(pymake.shutil, "which", lambda exe: None)
     monkeypatch.setattr(subprocess, "call", fake_call)
     ret = pymake.main(["lint"])
+    repo_root = Path(__file__).resolve().parents[1]
     expected = [
         "powershell",
         "-NoProfile",
         "-ExecutionPolicy",
         "Bypass",
         "-File",
-        str(script_path),
+        str(repo_root / "scripts" / "lint.ps1"),
     ]
     assert ret == 0
     assert calls == [expected]


### PR DESCRIPTION
## Summary
- ensure stub commands work on Windows by creating `.cmd` files and adjusting `PATHEXT`
- update pymake tests for absolute script paths
- log test change in NOTES

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687a1673db0c8325bab7f9267b2d84c9