### PR TITLE
Add npm win setup script

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1353,3 +1353,10 @@ TODO logs the task.
 - **Stage**: testing
 - **Motivation / Decision**: ensure wrapper failure detection on Windows.
 - **Next step**: none.
+
+### 2025-07-22  PR #176
+
+- **Summary**: added `win:setup` npm script and updated README for Windows setup.
+- **Stage**: documentation
+- **Motivation / Decision**: provide easier bootstrap on Windows using npm.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Additional assumptions and edge cases for the first feature are listed in
 
 Clone the repository and run the setup script to install Python and Node
 packages.
-On Linux or macOS use **`./.codex/setup.sh`**. Windows users can run
-**`scripts/setup.ps1`** from PowerShell.
+On Linux or macOS use **`./.codex/setup.sh`**.
+Windows users can run **`scripts/setup.ps1`** or
+`npm run win:setup` from PowerShell.
 The project requires Node 20 or newer.
 Then check the code:
 
@@ -27,7 +28,7 @@ Then check the code:
 git clone <repo-url>
 cd PoseDetection
 # run once with network access to fetch pre-commit hooks
-./.codex/setup.sh   # Windows: scripts/setup.ps1
+./.codex/setup.sh   # Windows: scripts/setup.ps1 or npm run win:setup
 make lint
 make test
 # Windows users without make can run:
@@ -100,7 +101,8 @@ Dependabot reviews `requirements.txt`, `package.json` and
 
 Run the provided setup script after cloning to install Python 3.11 (set
 `PYTHON_VERSION` to override) and Node 20 (set `NODE_VERSION` to change).
-On Windows use `scripts/setup.ps1`; other platforms use `.codex/setup.sh`.
+On Windows run `scripts/setup.ps1` or `npm run win:setup`.
+Other platforms use `.codex/setup.sh`.
 This installs `black` from `requirements.txt` so
 `make lint` works even when hooks are skipped. Tests rely on these packages,
 so always complete this step before running `make test`. The script is

--- a/TODO.md
+++ b/TODO.md
@@ -162,3 +162,4 @@
       `scripts/windows/` folder.
 - [x] Add tests for `pymake` and PowerShell wrappers.
 - [x] Ensure PowerShell wrapper scripts exit when commands fail.
+- [x] Add npm script `win:setup` and document running `npm run win:setup`.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "test": "jest",
     "build": "esbuild frontend/src/index.tsx --bundle --outfile=frontend/dist/bundle.js --format=iife --jsx=automatic",
+    "win:setup": "powershell -ExecutionPolicy Bypass -File scripts/setup.ps1",
     "win:lint": "powershell -ExecutionPolicy Bypass -File scripts/lint.ps1",
     "win:typecheck": "powershell -ExecutionPolicy Bypass -File scripts/typecheck.ps1",
     "win:typecheck-ts": "powershell -ExecutionPolicy Bypass -File scripts/typecheck-ts.ps1",


### PR DESCRIPTION
## Summary
- add `win:setup` to `package.json`
- mention `npm run win:setup` in the Windows instructions
- log the change in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`
- `python3 -m pre_commit run --files package.json README.md NOTES.md TODO.md`

------
https://chatgpt.com/codex/tasks/task_e_687a1ce6916483259d006edb8053a737