### PR TITLE
Add pymake lint step to Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,8 @@ jobs:
           SKIP_PRECOMMIT: '1'
       - run: scripts\lint.ps1
         shell: pwsh
+      - run: python pymake.py lint
+        shell: pwsh
       - run: scripts\typecheck.ps1
         shell: pwsh
       - run: scripts\typecheck-ts.ps1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.44 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.45 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -255,6 +255,8 @@ jobs:
         env:
           SKIP_PRECOMMIT: '1'
       - run: scripts\lint.ps1
+        shell: pwsh
+      - run: python pymake.py lint
         shell: pwsh
       - run: scripts\typecheck.ps1
         shell: pwsh

--- a/NOTES.md
+++ b/NOTES.md
@@ -1353,3 +1353,10 @@ TODO logs the task.
 - **Stage**: testing
 - **Motivation / Decision**: ensure wrapper failure detection on Windows.
 - **Next step**: none.
+
+### 2025-07-22  PR #-
+
+- **Summary**: test-win job now runs `python pymake.py lint` after `scripts\\lint.ps1`.
+- **Stage**: implementation
+- **Motivation / Decision**: mirror Windows lint steps to manual instructions.
+- **Next step**: none.


### PR DESCRIPTION
## Summary
- run `python pymake.py lint` after linting in the Windows CI job
- document the new step in `AGENTS.md`
- record the change in `NOTES.md`

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`
- `python -m pre_commit run --files .github/workflows/ci.yml AGENTS.md NOTES.md`
- `make lint-docs`


------
https://chatgpt.com/codex/tasks/task_e_687a1cea001c8325b52b34f799dab052