### PR TITLE
Include server in coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,3 @@
 [run]
 omit =
     generated/*
-    backend/server.py

--- a/NOTES.md
+++ b/NOTES.md
@@ -1366,3 +1366,10 @@ TODO logs the task.
 - **Stage**: documentation
 - **Motivation / Decision**: provide easier bootstrap on Windows using npm.
 - **Next step**: none.
+
+### 2025-07-18  PR #199
+
+- **Summary**: coverage now includes `backend/server.py`.
+- **Stage**: maintenance
+- **Motivation / Decision**: cover server module; coverage remains above 80%.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -163,3 +163,5 @@
 - [x] Add tests for `pymake` and PowerShell wrappers.
 - [x] Ensure PowerShell wrapper scripts exit when commands fail.
 - [x] Add npm script `win:setup` and document running `npm run win:setup`.
+- [x] Include `backend/server.py` in coverage checks by removing it from
+      `.coveragerc` omit list.


### PR DESCRIPTION
## Summary
- measure backend server in coverage
- record reasoning in NOTES
- update TODO roadmap

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687a231babb4832594912f9189e90198