### PR TITLE
Release camera once after open failure

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1405,3 +1405,10 @@ TODO logs the task.
 - **Stage**: implementation
 - **Motivation / Decision**: prevent hanging websocket when webcam unavailable.
 - **Next step**: none.
+
+### 2025-07-18  PR #181
+
+- **Summary**: camera release happens only once via finally block.
+- **Stage**: implementation
+- **Motivation / Decision**: avoid duplicate release when camera fails to open.
+- **Next step**: none.

--- a/backend/server.py
+++ b/backend/server.py
@@ -52,13 +52,13 @@ async def pose_endpoint(ws: WebSocket) -> None:
     """Stream pose metrics over WebSocket."""
     await ws.accept()
     cap = cv2.VideoCapture(0)
-    if not cap.isOpened():
-        await ws.send_text(json.dumps({"error": "camera failed"}))
-        await ws.close()
-        cap.release()
-        return
-    detector = PoseDetector()
+    detector: PoseDetector | None = None
     try:
+        if not cap.isOpened():
+            await ws.send_text(json.dumps({"error": "camera failed"}))
+            await ws.close()
+            return
+        detector = PoseDetector()
         while True:
             ok, frame = await _read_frame(cap)
             if not ok:
@@ -86,7 +86,8 @@ async def pose_endpoint(ws: WebSocket) -> None:
         raise
     finally:
         cap.release()
-        detector.close()
+        if detector:
+            detector.close()
 
 
 def main() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -97,6 +97,7 @@ class DummyPose:
 class DummyCap:
     def __init__(self) -> None:
         self.released = False
+        self.release_calls = 0
 
     def read(self) -> tuple[bool, None]:
         return False, None
@@ -105,6 +106,7 @@ class DummyCap:
         return True
 
     def release(self) -> None:
+        self.release_calls += 1
         self.released = True
 
 
@@ -241,6 +243,7 @@ def test_pose_endpoint_handles_camera_open_failure(monkeypatch):
     assert ws.sent == ['{"error": "camera failed"}']
     assert ws.closed is True
     assert cap.released is True
+    assert cap.release_calls == 1
 
 
 def test_pose_endpoint_reports_no_landmarks(monkeypatch):


### PR DESCRIPTION
## Summary
- refactor `pose_endpoint` to release the camera in a final block
- track camera release calls in tests
- test that the camera is released once when opening fails
- document change in NOTES

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`
- `python -m pre_commit run --files backend/server.py tests/test_server.py NOTES.md`

------
https://chatgpt.com/codex/tasks/task_e_687a2c9108cc8325a35412688a3e6db9