### PR TITLE
Extend lint & typecheck to root scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.45 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.46 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -125,12 +125,12 @@ prevents GitHub prompts.
       `requirements.txt`, `package.json` or `package-lock.json` change.
     - Run `make docs` to build the HTML docs into `docs/_build`.
     - Markdownlint reads `.markdownlintignore` to skip build and cache dirs.
-    - Python code under `scripts/` and `tests/` is linted with `ruff` via `make lint`.
-    - Static type checking uses mypy via `make typecheck`.
+    - `make lint` runs `ruff` across all Python sources, including
+      `backend/`, `scripts/`, `tests/` and root scripts like `pymake.py`.
+    - Static type checking uses mypy via `make typecheck` on those same files.
     - TypeScript compile checks run via `make typecheck-ts`.
-    - Python code in `backend/`, `scripts/`, `tests/`, and `docs/` is
-      formatted with `black`. `ruff` still checks only `backend/`, `scripts/`
-      and `tests/` via `make lint`.
+    - `black` formats `backend/`, `scripts/`, `tests/`, `docs/` and root
+      scripts.
     - GitHub Actions workflows are linted with
       `actionlint` pinned at v1.7.7 via pre-commit.
     - `make test` expects dependencies from `.codex/setup.sh`.

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 
 lint:
 	npx --yes markdownlint-cli '**/*.md' --ignore node_modules --ignore .pre-commit-cache --ignore frontend/dist --ignore docs/_build
-	black --check backend scripts tests docs
-	ruff check backend scripts tests
+	black --check backend scripts tests docs pymake.py
+	ruff check backend scripts tests pymake.py
 	python scripts/repo_checks.py
 
 lint-docs:
@@ -34,7 +34,7 @@ generate:
 
 
 typecheck:
-	mypy backend
+	mypy backend scripts pymake.py
 
 typecheck-ts:
 	npx --yes tsc --noEmit -p frontend/tsconfig.json

--- a/NOTES.md
+++ b/NOTES.md
@@ -1405,3 +1405,10 @@ TODO logs the task.
 - **Stage**: implementation
 - **Motivation / Decision**: prevent hanging websocket when webcam unavailable.
 - **Next step**: none.
+
+### 2025-07-18  PR #181
+
+- **Summary**: lint and typecheck now include `pymake.py`; docs updated.
+- **Stage**: implementation
+- **Motivation / Decision**: ensure root scripts are covered by quality tools.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -167,3 +167,4 @@
 - [x] Include `backend/server.py` in coverage checks by removing it from
       `.coveragerc` omit list.
 - [x] Handle camera open failure in pose_endpoint.
+- [x] Lint and typecheck cover `pymake.py` and scripts.


### PR DESCRIPTION
## Summary
- lint Makefile rules check `pymake.py`
- typecheck also covers scripts and `pymake.py`
- document lint & typecheck coverage in AGENTS
- log the change in NOTES and mark TODO item

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687a2c95d34c8325b70af941a770053e