### PR TITLE
Clarify useWebSocket host

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -41,8 +41,6 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: explain quick start and link to tech challenge.
 - **Next step**: none.
 
-### 2025-07-18  PR #178a
-
 - **Summary**: Metrics panel now wraps each metric in its own
   paragraph; tests updated and README clarified vertical display.
 - **Stage**: implementation
@@ -1404,4 +1402,12 @@ TODO logs the task.
 - **Summary**: handled camera open failure in `pose_endpoint`.
 - **Stage**: implementation
 - **Motivation / Decision**: prevent hanging websocket when webcam unavailable.
+- **Next step**: none.
+
+### 2025-07-18  PR #181
+
+- **Summary**: clarified README about passing only hostname/IP to
+  `useWebSocket`.
+- **Stage**: documentation
+- **Motivation / Decision**: avoid confusion over protocol prefixes.
 - **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ video stack on top of each other.
 The `useWebSocket` hook returns the latest pose data and a connection state
 (`connecting`, `open`, `closed` or `error`). PoseViewer displays this state so
 you know if the backend is reachable. The hook accepts optional `host` and
-`port` arguments when you need to connect to another server. Messages may
+`port` arguments when you need to connect to another server. `host` must be
+a hostname or IP address without a protocol prefix. Messages may
 contain an `error` field; the hook exposes this via an `error` property and
 leaves the pose data unchanged so the UI can show the problem.
 
@@ -190,8 +191,8 @@ Then open [http://localhost:8000/](http://localhost:8000/) <!-- lychee skip -->
 in your browser. This mount is optional; if `frontend/dist` is missing you
 can still serve the files with another HTTP server.
 The page connects to `ws://localhost:8000/pose` by default. To reach a remote
-server pass the host and port to `useWebSocket`, for example
-`useWebSocket('/pose', 'example.org', 9001)`.
+server pass the host and port to `useWebSocket`. The host should be just the
+hostname or IP address, for example `useWebSocket('/pose', 'example.org', 9001)`.
 
 ## Backend
 

--- a/TODO.md
+++ b/TODO.md
@@ -167,3 +167,4 @@
 - [x] Include `backend/server.py` in coverage checks by removing it from
       `.coveragerc` omit list.
 - [x] Handle camera open failure in pose_endpoint.
+- [x] Clarify that `useWebSocket` host parameter should omit protocol prefix in README.


### PR DESCRIPTION
## Summary
- clarify README about the `host` param for `useWebSocket`
- note the docs clarification in NOTES
- mark TODO item for this docs tweak

## Testing
- `make lint-docs`

------
https://chatgpt.com/codex/tasks/task_e_687a2ca4ab80832582dd7c4eaa449ca2