### PR TITLE
Update VS setup docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.46 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.47 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -63,32 +63,35 @@ prevents GitHub prompts.
    PowerShell. *The script installs Python, Node and all packages needed for
    tests.* Set `PYTHON_VERSION` or `NODE_VERSION` to override the defaults
    (3.11 and 20). Always complete this step before running any test or build.
-2. Export **required secrets** (`GIT_TOKEN`, `GH_PAGES_TOKEN`, …)
+2. Run the setup script inside your active Python environment. IDEs may
+   create a new `.venv`, so rerun it there (or `pip install -r requirements.txt`)
+   before starting the backend.
+3. Export **required secrets** (`GIT_TOKEN`, `GH_PAGES_TOKEN`, …)
    in the repository/organisation **Secrets** console.
-3. Verify the **secret‑detection helper step** in
+4. Verify the **secret‑detection helper step** in
     `.github/workflows/ci.yml` (see § 4) so forks without secrets still pass.
-4. Pushes to `main` run `.github/workflows/pages.yml` which builds the Sphinx
+5. Pushes to `main` run `.github/workflows/pages.yml` which builds the Sphinx
    docs, uploads them using `actions/upload-pages-artifact@v3` and deploys them
    to GitHub Pages when `GH_PAGES_TOKEN` is present. Enable Pages in the repo
    settings with **GitHub Actions** as the source. `GH_PAGES_TOKEN` requires
    `pages:write` and repo access.
-5. On the first PR, update README badges to point at your fork (owner/repo).
-6. `.codex/setup.sh` installs `pre-commit`, sets up the hooks and then runs
+6. On the first PR, update README badges to point at your fork (owner/repo).
+7. `.codex/setup.sh` installs `pre-commit`, sets up the hooks and then runs
    `pre-commit run --all-files`. This may reformat files, so run the script
    before editing anything. Hooks are installed using `python3 -m pre_commit`
    on the first run to avoid PATH issues. Set `SKIP_PRECOMMIT=1` to bypass this
    when offline. The CI workflow passes this flag because the runners have
    restricted network access.
-7. `black` is pinned in `requirements.txt` so `make lint` works when
+8. `black` is pinned in `requirements.txt` so `make lint` works when
    pre-commit hooks are skipped.
-8. `mypy` is pinned in `requirements.txt` so `make typecheck` works.
-9. When using pyenv, run `pyenv rehash` after package installs so new
+9. `mypy` is pinned in `requirements.txt` so `make typecheck` works.
+10. When using pyenv, run `pyenv rehash` after package installs so new
    shims are picked up.
-10. A `Dockerfile` sets up Python 3.11 and Node 20. Build it with
+11. A `Dockerfile` sets up Python 3.11 and Node 20. Build it with
    `docker build -t posedetect .` to run tests in a container.
-11. Run `python pymake.py <target>` when `make` is unavailable. The wrapper
+12. Run `python pymake.py <target>` when `make` is unavailable. The wrapper
     calls `make` on Unix and the PowerShell scripts on Windows.
-12. Windows users without `make` can still run the wrappers via
+13. Windows users without `make` can still run the wrappers via
     `npm run win:lint` or directly from `scripts/<name>.ps1` (for example
     `scripts/lint.ps1`).
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1423,3 +1423,12 @@ TODO logs the task.
 - **Stage**: implementation
 - **Motivation / Decision**: ensure root scripts are covered by quality tools.
 - **Next step**: none.
+
+### 2025-07-19  PR #184
+
+- **Summary**: clarified VS setup instructions.
+  Added note on rerunning the setup script inside new virtual environments.
+- **Stage**: documentation
+- **Motivation / Decision**: help Windows users avoid missing packages when
+  IDEs create `.venv` folders.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,11 @@ Follow these steps to run the backend from Visual Studio:
 4. Right‑click `backend/server.py` and pick **Set as Startup File**.
 5. Press **F5** to launch the FastAPI server.
 
+`scripts/setup.ps1` installs packages for the interpreter currently
+active. When VS creates a new `.venv`, run the script again inside that
+environment or use `pip install -r requirements.txt` before launching
+the backend.
+
 Install Node separately to build the React frontend with `npm run build`.
 
 If `make` does not work on your platform use the provided PowerShell wrappers

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO – Road‑map (last updated: 2025-07-18)
+# TODO – Road‑map (last updated: 2025-07-19)
 
 > *Record only high‑level milestones here; break micro‑tasks out into Issues.*
 > **When you finish a task, tick it and append a short NOTE entry
@@ -169,3 +169,5 @@
 - [x] Handle camera open failure in pose_endpoint.
 - [x] Clarify that `useWebSocket` host parameter should omit protocol prefix in README.
 - [x] Lint and typecheck cover `pymake.py` and scripts.
+- [x] Explain that `scripts/setup.ps1` installs packages for the active Python
+  interpreter and rerun it when an IDE creates a new `.venv`.


### PR DESCRIPTION
## Summary
- document rerunning `scripts/setup.ps1` after Visual Studio creates a `.venv`
- remind contributors to run the setup script in the active Python environment
- record the new guidance in AGENTS and TODO
- add entry in NOTES

## Testing
- `make lint-docs`
- `make update-todo-date`


------
https://chatgpt.com/codex/tasks/task_e_687b7e9d5e14832582eea5af0346a442