### PR TITLE
Fix WebSocket path dispatch

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1432,3 +1432,11 @@ TODO logs the task.
 - **Motivation / Decision**: help Windows users avoid missing packages when
   IDEs create `.venv` folders.
 - **Next step**: none.
+
+### 2025-07-19  PR #185
+
+- **Summary**: moved static mount after routes to fix WebSocket endpoint order.
+  Added test for route order.
+- **Stage**: implementation
+- **Motivation / Decision**: prevent StaticFiles from catching WebSocket traffic.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO – Road‑map (last updated: 2025-07-19)
+# TODO – Road‑map (last updated: 2025-07-20)
 
 > *Record only high‑level milestones here; break micro‑tasks out into Issues.*
 > **When you finish a task, tick it and append a short NOTE entry
@@ -171,3 +171,4 @@
 - [x] Lint and typecheck cover `pymake.py` and scripts.
 - [x] Explain that `scripts/setup.ps1` installs packages for the active Python
   interpreter and rerun it when an IDE creates a new `.venv`.
+- [x] Serve static files after defining routes so WebSocket connections work.

--- a/backend/server.py
+++ b/backend/server.py
@@ -14,11 +14,6 @@ from .pose_detector import PoseDetector
 import uvicorn
 
 app = FastAPI()
-app.mount(
-    "/",
-    StaticFiles(directory="frontend/dist", html=True),
-    name="static",
-)
 
 # names for the 17-landmark subset used by PoseDetector
 _NAMES = [lm.name.lower() for lm in PoseDetector.LANDMARKS]
@@ -88,6 +83,13 @@ async def pose_endpoint(ws: WebSocket) -> None:
         cap.release()
         if detector:
             detector.close()
+
+
+app.mount(
+    "/",
+    StaticFiles(directory="frontend/dist", html=True),
+    name="static",
+)
 
 
 def main() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -67,6 +67,21 @@ def test_root_mount_present():
         raise AssertionError("root mount not found")
 
 
+def test_pose_route_before_static_mount():
+    import backend.server as server
+    from fastapi.staticfiles import StaticFiles
+
+    pose_idx = static_idx = None
+    for idx, route in enumerate(server.app.routes):
+        if getattr(route, "path", None) == "/pose":
+            pose_idx = idx
+        if getattr(route, "path", None) in ("/", "") and hasattr(route, "app"):
+            if isinstance(getattr(route, "app"), StaticFiles):
+                static_idx = idx
+    assert pose_idx is not None and static_idx is not None
+    assert pose_idx < static_idx
+
+
 class DummyWS:
     def __init__(self):
         self.accepted = False


### PR DESCRIPTION
## Summary
- ensure WebSocket connections aren't caught by StaticFiles
- add regression test for route order
- document new milestone in TODO and NOTES

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687b8cb94d408325a9f8634ea734b2d1