### PR TITLE
Stream frames over WebSocket

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1440,3 +1440,11 @@ TODO logs the task.
 - **Stage**: implementation
 - **Motivation / Decision**: prevent StaticFiles from catching WebSocket traffic.
 - **Next step**: none.
+
+### 2025-07-20  PR #186
+
+- **Summary**: PoseViewer now sends each webcam frame as a JPEG blob over the WebSocket.
+  useWebSocket exposes a `send` method and parses binary messages. Tests updated.
+- **Stage**: implementation
+- **Motivation / Decision**: allow remote pose detection by streaming frames.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -172,3 +172,4 @@
 - [x] Explain that `scripts/setup.ps1` installs packages for the active Python
   interpreter and rerun it when an IDE creates a new `.venv`.
 - [x] Serve static files after defining routes so WebSocket connections work.
+- [x] Send webcam frames as JPEG blobs over WebSocket.

--- a/frontend/src/__tests__/PoseViewerError.test.tsx
+++ b/frontend/src/__tests__/PoseViewerError.test.tsx
@@ -4,7 +4,7 @@ import PoseViewer from '../components/PoseViewer';
 
 jest.mock('../hooks/useWebSocket', () => ({
   __esModule: true,
-  default: () => ({ poseData: null, status: 'open', error: 'failed to parse' }),
+  default: () => ({ poseData: null, status: 'open', error: 'failed to parse', send: jest.fn() }),
 }));
 
 test('renders WebSocket error message', () => {

--- a/frontend/src/__tests__/useWebSocket.test.tsx
+++ b/frontend/src/__tests__/useWebSocket.test.tsx
@@ -30,6 +30,7 @@ class MockWebSocket {
   onerror: (() => void) | null = null;
   onmessage: ((ev: { data: string }) => void) | null = null;
   constructor(public url: string) {}
+  send = jest.fn();
   triggerOpen() {
     this.onopen?.();
   }
@@ -123,6 +124,24 @@ test('close function sets status to closed', () => {
     result.current.close();
   });
   expect(result.current.status).toBe('closed');
+
+  window.WebSocket = OriginalWebSocket;
+});
+
+test('send function forwards data to WebSocket', () => {
+  const ws = new MockWebSocket('ws://test');
+  const OriginalWebSocket = window.WebSocket;
+  // @ts-ignore
+  window.WebSocket = jest.fn(() => ws);
+
+  const { result } = renderHook(() => useWebSocket('/pose'));
+
+  act(() => {
+    ws.triggerOpen();
+    result.current.send(new Blob());
+  });
+
+  expect(ws.send).toHaveBeenCalled();
 
   window.WebSocket = OriginalWebSocket;
 });


### PR DESCRIPTION
## Summary
- send each webcam frame via an off-screen canvas
- let `useWebSocket` send binary data and parse JSON regardless of frame type
- test the new behaviour
- note JPEG streaming in NOTES and mark TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687b9cbfbb8083259afe857c38676bea