### PR TITLE
Fix metrics panel overlay

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1466,3 +1466,10 @@ TODO logs the task.
 - **Motivation / Decision**: keep documentation in sync after moving webcam
   capture to the client.
 - **Next step**: none.
+\n### 2025-07-20  PR #xxx
+- **Summary**: removed fixed height from .pose-container so metrics panel
+  shows below the video overlay; updated README.
+- **Stage**: bugfix
+- **Motivation / Decision**: CSS overlay hid metrics because container
+  height restricted it; letting it grow exposes the panel.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ WebSocket connection. It calls `setStreaming(!streaming)` in
 draws lines between keypoints to show the pose skeleton. The canvas size is
 set from the video's `loadedmetadata` event so it matches the actual webcam
 resolution. The surrounding `.pose-container` is styled so the canvas and
-video stack on top of each other.
+video stack on top of each other. The container does not set a fixed height
+so the metrics panel renders below the video overlay.
 The `useWebSocket` hook returns the latest pose data and a connection state
 (`connecting`, `open`, `closed` or `error`). PoseViewer displays this state so
 you know if the backend is reachable. The hook accepts optional `host` and

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO – Road‑map (last updated: 2025-07-19)
+# TODO – Road‑map (last updated: 2025-07-20)
 
 > *Record only high‑level milestones here; break micro‑tasks out into Issues.*
 > **When you finish a task, tick it and append a short NOTE entry
@@ -174,3 +174,4 @@
 - [x] Serve static files after defining routes so WebSocket connections work.
 - [x] Receive JPEG frames from clients over `/pose` WebSocket and decode them server-side.
 - [x] Send webcam frames as JPEG blobs over WebSocket.
+- [ ] Remove fixed height from .pose-container so metrics show below the video.

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -12,7 +12,6 @@
     .pose-container {
       position: relative;
       width: 640px;
-      height: 480px;
     }
     .pose-container video,
     .pose-container canvas {


### PR DESCRIPTION
## Summary
- let `.pose-container` expand so metrics panel appears below the video
- document the container change
- log the fix in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687cbab11e648325afd4159ad0a0a64f