### PR TITLE
Align overlay canvas to video

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1473,3 +1473,12 @@ TODO logs the task.
 - **Motivation / Decision**: CSS overlay hid metrics because container
   height restricted it; letting it grow exposes the panel.
 - **Next step**: none.
+
+### 2025-07-21  PR #yyy
+
+- **Summary**: added alignCanvasToVideo helper to keep the overlay sized to the
+  video and updated tests and docs.
+- **Stage**: implementation
+- **Motivation / Decision**: ensure the overlay resizes correctly when the video
+  element scales, matching new TODO item.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -159,11 +159,13 @@ The PoseViewer component shows the live webcam feed. The **Start Webcam**
 button toggles streaming on and off. Stopping the webcam also closes the
 WebSocket connection. It calls `setStreaming(!streaming)` in
 [`PoseViewer.tsx`](frontend/src/components/PoseViewer.tsx). A canvas overlay
-draws lines between keypoints to show the pose skeleton. The canvas size is
-set from the video's `loadedmetadata` event so it matches the actual webcam
-resolution. The surrounding `.pose-container` is styled so the canvas and
-video stack on top of each other. The container does not set a fixed height
-so the metrics panel renders below the video overlay.
+draws lines between keypoints to show the pose skeleton. The helper
+`alignCanvasToVideo` reads `video.getBoundingClientRect()` and updates the
+canvas so it always covers the visible video area. It runs once after the
+`loadedmetadata` event and before each frame is drawn. The surrounding
+`.pose-container` is styled so the canvas and video stack on top of each other.
+The container does not set a fixed height so the metrics panel renders below
+the video overlay.
 The `useWebSocket` hook returns the latest pose data and a connection state
 (`connecting`, `open`, `closed` or `error`). PoseViewer displays this state so
 you know if the backend is reachable. The hook accepts optional `host` and

--- a/TODO.md
+++ b/TODO.md
@@ -174,4 +174,4 @@
 - [x] Serve static files after defining routes so WebSocket connections work.
 - [x] Receive JPEG frames from clients over `/pose` WebSocket and decode them server-side.
 - [x] Send webcam frames as JPEG blobs over WebSocket.
-- [ ] Remove fixed height from .pose-container so metrics show below the video.
+- [x] Remove fixed height from .pose-container so metrics show below the video.

--- a/frontend/src/__tests__/PoseViewerError.test.tsx
+++ b/frontend/src/__tests__/PoseViewerError.test.tsx
@@ -7,6 +7,34 @@ jest.mock('../hooks/useWebSocket', () => ({
   default: () => ({ poseData: null, status: 'open', error: 'failed to parse', send: jest.fn() }),
 }));
 
+beforeEach(() => {
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value: function () {
+      return {
+        canvas: this,
+        drawImage: jest.fn(),
+        clearRect: jest.fn(),
+        beginPath: jest.fn(),
+        moveTo: jest.fn(),
+        lineTo: jest.fn(),
+        stroke: jest.fn(),
+        arc: jest.fn(),
+        fill: jest.fn(),
+      } as unknown as CanvasRenderingContext2D;
+    },
+  });
+  Object.defineProperty(HTMLCanvasElement.prototype, 'toBlob', {
+    configurable: true,
+    value: (cb: (b: Blob) => void) => cb(new Blob()),
+  });
+});
+
+afterEach(() => {
+  delete (HTMLCanvasElement.prototype as any).getContext;
+  delete (HTMLCanvasElement.prototype as any).toBlob;
+});
+
 test('renders WebSocket error message', () => {
   class FakeStream {
     getTracks() {

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import useWebSocket from '../hooks/useWebSocket';
 import { drawSkeleton, Point } from '../utils/poseDrawing';
+import alignCanvasToVideo from '../utils/alignCanvas';
 import MetricsPanel, { PoseMetrics } from './MetricsPanel';
 
 interface PoseData {
@@ -23,8 +24,7 @@ const PoseViewer: React.FC = () => {
     const video = videoRef.current;
     const canvas = canvasRef.current;
     if (!video || !canvas) return;
-    canvas.width = video.videoWidth;
-    canvas.height = video.videoHeight;
+    alignCanvasToVideo(video, canvas);
   };
 
   useEffect(() => {
@@ -84,7 +84,9 @@ const PoseViewer: React.FC = () => {
 
   useEffect(() => {
     const canvas = canvasRef.current;
-    if (!canvas || !poseData) return;
+    const video = videoRef.current;
+    if (!canvas || !video || !poseData) return;
+    alignCanvasToVideo(video, canvas);
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     drawSkeleton(ctx, poseData.landmarks);

--- a/frontend/src/utils/alignCanvas.ts
+++ b/frontend/src/utils/alignCanvas.ts
@@ -1,0 +1,10 @@
+export default function alignCanvasToVideo(
+  video: HTMLVideoElement,
+  canvas: HTMLCanvasElement,
+): void {
+  const rect = video.getBoundingClientRect();
+  canvas.width = rect.width;
+  canvas.height = rect.height;
+  canvas.style.width = `${rect.width}px`;
+  canvas.style.height = `${rect.height}px`;
+}


### PR DESCRIPTION
## Summary
- resize overlay canvas based on visible video element
- keep overlay in sync on every draw call
- adjust PoseViewer tests for new resize logic
- document alignCanvasToVideo helper in README
- tick TODO for pose container height
- log the update in NOTES

## Testing
- `python3 -m pre_commit run --files NOTES.md README.md TODO.md frontend/src/__tests__/PoseViewer.test.tsx frontend/src/components/PoseViewer.tsx frontend/src/utils/alignCanvas.ts frontend/src/__tests__/PoseViewerError.test.tsx`
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687ccc0550d0832596ad50805df52b58