### PR TITLE
Improve pose overlay scaling

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1482,3 +1482,12 @@ TODO logs the task.
 - **Motivation / Decision**: ensure the overlay resizes correctly when the video
   element scales, matching new TODO item.
 - **Next step**: none.
+
+### 2025-07-21  PR #zzz
+
+- **Summary**: canvas overlay now respects device pixel ratio and handles
+  mirroring via `ResizeObserver` in PoseViewer. Updated tests and README.
+- **Stage**: implementation
+- **Motivation / Decision**: improve drawing quality on high‑DPI screens and
+  avoid resizing work on every frame.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -160,9 +160,11 @@ button toggles streaming on and off. Stopping the webcam also closes the
 WebSocket connection. It calls `setStreaming(!streaming)` in
 [`PoseViewer.tsx`](frontend/src/components/PoseViewer.tsx). A canvas overlay
 draws lines between keypoints to show the pose skeleton. The helper
-`alignCanvasToVideo` reads `video.getBoundingClientRect()` and updates the
-canvas so it always covers the visible video area. It runs once after the
-`loadedmetadata` event and before each frame is drawn. The surrounding
+`alignCanvasToVideo` multiplies the video bounds by
+`window.devicePixelRatio` so the overlay stays crisp. A `ResizeObserver`
+updates the canvas after `loadedmetadata` and whenever the video element
+resizes. When drawing, PoseViewer scales the context from the actual video
+size and flips horizontally if the video is mirrored. The surrounding
 `.pose-container` is styled so the canvas and video stack on top of each other.
 The container does not set a fixed height so the metrics panel renders below
 the video overlay.

--- a/TODO.md
+++ b/TODO.md
@@ -175,3 +175,5 @@
 - [x] Receive JPEG frames from clients over `/pose` WebSocket and decode them server-side.
 - [x] Send webcam frames as JPEG blobs over WebSocket.
 - [x] Remove fixed height from .pose-container so metrics show below the video.
+- [x] Handle device pixel ratio and mirroring in PoseViewer overlay using a
+      ResizeObserver.

--- a/frontend/src/__tests__/PoseViewerError.test.tsx
+++ b/frontend/src/__tests__/PoseViewerError.test.tsx
@@ -7,7 +7,17 @@ jest.mock('../hooks/useWebSocket', () => ({
   default: () => ({ poseData: null, status: 'open', error: 'failed to parse', send: jest.fn() }),
 }));
 
+let resizeCb: ResizeObserverCallback;
+class MockRO {
+  observe = jest.fn();
+  disconnect = jest.fn();
+  constructor(cb: ResizeObserverCallback) {
+    resizeCb = cb;
+  }
+}
+
 beforeEach(() => {
+  (global as any).ResizeObserver = MockRO as unknown as typeof ResizeObserver;
   Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
     configurable: true,
     value: function () {
@@ -21,6 +31,10 @@ beforeEach(() => {
         stroke: jest.fn(),
         arc: jest.fn(),
         fill: jest.fn(),
+        save: jest.fn(),
+        restore: jest.fn(),
+        scale: jest.fn(),
+        translate: jest.fn(),
       } as unknown as CanvasRenderingContext2D;
     },
   });
@@ -33,6 +47,7 @@ beforeEach(() => {
 afterEach(() => {
   delete (HTMLCanvasElement.prototype as any).getContext;
   delete (HTMLCanvasElement.prototype as any).toBlob;
+  delete (global as any).ResizeObserver;
 });
 
 test('renders WebSocket error message', () => {

--- a/frontend/src/utils/alignCanvas.ts
+++ b/frontend/src/utils/alignCanvas.ts
@@ -3,8 +3,9 @@ export default function alignCanvasToVideo(
   canvas: HTMLCanvasElement,
 ): void {
   const rect = video.getBoundingClientRect();
-  canvas.width = rect.width;
-  canvas.height = rect.height;
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = rect.width * dpr;
+  canvas.height = rect.height * dpr;
   canvas.style.width = `${rect.width}px`;
   canvas.style.height = `${rect.height}px`;
 }


### PR DESCRIPTION
## Summary
- handle device pixel ratio in `alignCanvasToVideo`
- scale canvas drawing to video dimensions and handle mirroring
- observe the video element and resize overlay when it changes
- update tests and docs

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687cd6e312e08325b73d41b11237eb59