### PR TITLE
Add PoseViewer scaling test

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1468,6 +1468,7 @@ TODO logs the task.
 - **Next step**: none.
 
 ### 2025-07-20  PR #189
+
 - **Summary**: removed fixed height from .pose-container so metrics panel
   shows below the video overlay; updated README.
 - **Stage**: bugfix
@@ -1498,4 +1499,13 @@ TODO logs the task.
 - **Stage**: implementation
 - **Motivation / Decision**: ensure crisp rendering on high-DPI screens and
   verify scaling logic via Jest.
+- **Next step**: none.
+
+### 2025-07-20  PR #193
+
+- **Summary**: added PoseViewer test for scaling logic and skeleton drawing
+  when video and layout sizes differ.
+- **Stage**: test
+- **Motivation / Decision**: verify `alignCanvasToVideo` and drawing
+  functions work together by checking context scale and coordinates.
 - **Next step**: none.


### PR DESCRIPTION
## Summary
- test canvas scaling with mocked DOMRect
- verify ctx.scale and drawn coordinates
- log entry for new tests

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687ce1330dfc832594e242a05ffaf16c