### PR TITLE
Fix canvas alignment docs

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1525,3 +1525,10 @@ TODO logs the task.
 - **Stage**: documentation
 - **Motivation / Decision**: keep README in sync with the scaling code.
 - **Next step**: none.
+
+### 2025-07-20  PR #196
+
+- **Summary**: clarified that `alignCanvasToVideo` only sizes the canvas using `devicePixelRatio`.
+- **Stage**: documentation
+- **Motivation / Decision**: drop transform reference so README matches code.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -161,8 +161,7 @@ WebSocket connection. It calls `setStreaming(!streaming)` in
 [`PoseViewer.tsx`](frontend/src/components/PoseViewer.tsx). A canvas overlay
 draws lines between keypoints to show the pose skeleton. The helper
 `alignCanvasToVideo` reads `video.getBoundingClientRect()` and
-multiplies the bounds by `window.devicePixelRatio`. It also sets a
-context transform so drawing uses video pixels. A `ResizeObserver`
+uses `window.devicePixelRatio` to size the canvas. A `ResizeObserver`
 updates the canvas after `loadedmetadata` and whenever the video element
 resizes. When drawing, PoseViewer saves the context, scales from the
 video size and flips horizontally if the video is mirrored. The


### PR DESCRIPTION
## Summary
- clarify that `alignCanvasToVideo` only sizes the canvas
- keep documentation about resize and mirroring
- log the update in NOTES

## Testing
- `make lint-docs`

------
https://chatgpt.com/codex/tasks/task_e_687ce853407c8325892fc9f88281af7e