### PR TITLE
Add mirroring check in PoseViewer test

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1525,3 +1525,10 @@ TODO logs the task.
 - **Stage**: documentation
 - **Motivation / Decision**: keep README in sync with the scaling code.
 - **Next step**: none.
+
+### 2025-07-20  PR #196
+
+- **Summary**: added test for mirroring via getComputedStyle.
+- **Stage**: testing
+- **Motivation / Decision**: verify overlay handles flipped video.
+- **Next step**: none.


### PR DESCRIPTION
## Summary
- mock `getComputedStyle` in PoseViewer tests to simulate mirrored video
- verify `ctx.translate` and `ctx.scale` are called with mirroring values
- document the change in NOTES

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`
- `python -m pre_commit run --files frontend/src/__tests__/PoseViewer.test.tsx NOTES.md`


------
https://chatgpt.com/codex/tasks/task_e_687ce847a7088325970f8eff252ce52f