### PR TITLE
Fix overlay skeleton scale

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1553,10 +1553,18 @@ TODO logs the task.
 - **Motivation / Decision**: drop transform reference so README matches code.
 - **Next step**: none.
 
-### 2025-07-20
+### 2025-07-20  PR #200
 
 - **Summary**: reset overlay transform before scaling and removed scaling from
   `drawSkeleton`. Updated tests accordingly.
 - **Stage**: implementation
 - **Motivation / Decision**: ensure consistent rendering after canvas resizes and
   simplify poseDrawing logic.
+
+### 2025-07-20
+
+- **Summary**: converted normalized landmarks to pixels in `drawSkeleton` and
+  applied line width scaling in `PoseViewer`. Updated docs and tests.
+- **Stage**: implementation
+- **Motivation / Decision**: fix incorrect overlay coordinates when using
+  intrinsic video dimensions.

--- a/TODO.md
+++ b/TODO.md
@@ -180,3 +180,5 @@
 - [x] Scale pose drawing context during render instead of via
       `alignCanvasToVideo`.
 - [x] Refactor overlay scaling logic and update tests accordingly.
+- [x] Convert normalized landmarks to pixels in `drawSkeleton` for accurate
+      overlay scaling.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,10 @@ The pose detector outputs 17 landmarks in the following order:
 ``left_wrist``, ``right_wrist``, ``left_hip``, ``right_hip``, ``left_knee``,
 ``right_knee``, ``left_ankle`` and ``right_ankle``.
 
+The landmark coordinates are normalized between 0 and 1. When drawing the
+pose skeleton these values are multiplied by the video's width and height to
+obtain pixel positions.
+
 ## Backend analytics
 
 The backend exposes a WebSocket endpoint at `/pose`. The browser captures

--- a/frontend/src/__tests__/poseDrawing.test.tsx
+++ b/frontend/src/__tests__/poseDrawing.test.tsx
@@ -13,6 +13,7 @@ const makeCtx = () => {
     fillStyle: '',
     strokeStyle: '',
     lineWidth: 0,
+    getTransform: () => ({ a: 1 }),
   } as unknown as CanvasRenderingContext2D;
 };
 
@@ -29,10 +30,10 @@ test('drawSkeleton connects edge landmarks', () => {
     const e = landmarks[edge[1]];
     const m = (ctx.moveTo as jest.Mock).mock.calls[i];
     const l = (ctx.lineTo as jest.Mock).mock.calls[i];
-    expect(m[0]).toBeCloseTo(s.x);
-    expect(m[1]).toBeCloseTo(s.y);
-    expect(l[0]).toBeCloseTo(e.x);
-    expect(l[1]).toBeCloseTo(e.y);
+    expect(m[0]).toBeCloseTo(s.x * 100);
+    expect(m[1]).toBeCloseTo(s.y * 100);
+    expect(l[0]).toBeCloseTo(e.x * 100);
+    expect(l[1]).toBeCloseTo(e.y * 100);
   });
 });
 

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -100,6 +100,7 @@ const PoseViewer: React.FC = () => {
     const sx = canvas.width / video.videoWidth;
     const sy = canvas.height / video.videoHeight;
     ctx.scale(sx, sy);
+    ctx.lineWidth = 2 / sx;
     const transform = getComputedStyle(video).transform;
     if (transform.startsWith('matrix(-1')) {
       ctx.translate(video.videoWidth, 0);

--- a/frontend/src/utils/poseDrawing.ts
+++ b/frontend/src/utils/poseDrawing.ts
@@ -32,25 +32,28 @@ export const EDGES: [number, number][] = [
 export function drawSkeleton(
   ctx: CanvasRenderingContext2D,
   landmarks: Point[],
-  _videoWidth: number,
-  _videoHeight: number,
+  videoWidth: number,
+  videoHeight: number,
 ): void {
-  ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+  const scale = typeof (ctx as any).getTransform === 'function'
+    ? (ctx as any).getTransform().a || 1
+    : 1;
   ctx.strokeStyle = 'lime';
-  ctx.lineWidth = 2;
+  ctx.lineWidth = 2 / scale;
   for (const [a, b] of EDGES) {
     const pa = landmarks[a];
     const pb = landmarks[b];
     if (!pa || !pb) continue;
     ctx.beginPath();
-    ctx.moveTo(pa.x, pa.y);
-    ctx.lineTo(pb.x, pb.y);
+    ctx.moveTo(pa.x * videoWidth, pa.y * videoHeight);
+    ctx.lineTo(pb.x * videoWidth, pb.y * videoHeight);
     ctx.stroke();
   }
   ctx.fillStyle = 'red';
+  const radius = 4 / scale;
   for (const p of landmarks) {
     ctx.beginPath();
-    ctx.arc(p.x, p.y, 4, 0, Math.PI * 2);
+    ctx.arc(p.x * videoWidth, p.y * videoHeight, radius, 0, Math.PI * 2);
     ctx.fill();
   }
 }


### PR DESCRIPTION
## Summary
- convert normalized pose landmarks to pixels in `drawSkeleton`
- resize skeleton lines and circles relative to the canvas scale
- set overlay line width after scaling
- verify scaled coordinates in unit tests
- document normalized landmark handling
- update roadmap and engineering notes

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687cf8b4cf3883258a8c24535c65bdd4