### PR TITLE
Fix poseDrawing scaling sign

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1568,3 +1568,11 @@ TODO logs the task.
 - **Stage**: implementation
 - **Motivation / Decision**: fix incorrect overlay coordinates when using
   intrinsic video dimensions.
+
+### 2025-07-20  PR #201
+
+- **Summary**: use absolute scale from `getTransform` so line width stays
+  positive when mirroring. Added test.
+- **Stage**: implementation
+- **Motivation / Decision**: ensure overlay drawing works after `ctx.scale(-1,1)`.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -182,3 +182,5 @@
 - [x] Refactor overlay scaling logic and update tests accordingly.
 - [x] Convert normalized landmarks to pixels in `drawSkeleton` for accurate
       overlay scaling.
+- [x] Use absolute scale from `getTransform` in `drawSkeleton` and ensure
+      positive line width.

--- a/frontend/src/__tests__/poseDrawing.test.tsx
+++ b/frontend/src/__tests__/poseDrawing.test.tsx
@@ -54,3 +54,15 @@ test('edges list matches 17-point skeleton', () => {
   ];
   expect(EDGES).toEqual(expected);
 });
+
+test('lineWidth remains positive when context is mirrored', () => {
+  const ctx = makeCtx();
+  let transform = { a: 1 };
+  (ctx as any).getTransform = () => transform;
+  (ctx as any).scale = (x: number, y: number) => {
+    transform = { a: transform.a * x };
+  };
+  (ctx as any).scale(-1, 1);
+  drawSkeleton(ctx, [{ x: 0, y: 0 }], 100, 100);
+  expect(ctx.lineWidth).toBeGreaterThan(0);
+});

--- a/frontend/src/utils/poseDrawing.ts
+++ b/frontend/src/utils/poseDrawing.ts
@@ -36,7 +36,7 @@ export function drawSkeleton(
   videoHeight: number,
 ): void {
   const scale = typeof (ctx as any).getTransform === 'function'
-    ? (ctx as any).getTransform().a || 1
+    ? Math.abs((ctx as any).getTransform().a) || 1
     : 1;
   ctx.strokeStyle = 'lime';
   ctx.lineWidth = 2 / scale;


### PR DESCRIPTION
## Summary
- use `Math.abs` when reading canvas transform in `drawSkeleton`
- add a regression test for mirrored canvases
- log the work in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`
- `make lint-docs`


------
https://chatgpt.com/codex/tasks/task_e_687cfe5eb69c83258f37ee8903b780f9