### PR TITLE
Fix pose viewer line width

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1561,10 +1561,18 @@ TODO logs the task.
 - **Motivation / Decision**: ensure consistent rendering after canvas resizes and
   simplify poseDrawing logic.
 
-### 2025-07-20
+### 2025-07-20  ctx.lineWidth cleanup
 
 - **Summary**: converted normalized landmarks to pixels in `drawSkeleton` and
   applied line width scaling in `PoseViewer`. Updated docs and tests.
 - **Stage**: implementation
 - **Motivation / Decision**: fix incorrect overlay coordinates when using
   intrinsic video dimensions.
+
+### 2025-07-20
+
+- **Summary**: removed line width assignment from `PoseViewer` and added a unit
+  test verifying `drawSkeleton` handles scaling. Reason: avoid redundant
+  `ctx.lineWidth` calls.
+- **Stage**: implementation
+- **Motivation / Decision**: keep drawing logic localized in `drawSkeleton`.

--- a/TODO.md
+++ b/TODO.md
@@ -182,3 +182,5 @@
 - [x] Refactor overlay scaling logic and update tests accordingly.
 - [x] Convert normalized landmarks to pixels in `drawSkeleton` for accurate
       overlay scaling.
+- [x] Set `ctx.lineWidth` only in `drawSkeleton` and remove duplicate call from
+      `PoseViewer`. Add test for scale handling.

--- a/frontend/src/__tests__/PoseViewer.test.tsx
+++ b/frontend/src/__tests__/PoseViewer.test.tsx
@@ -190,7 +190,6 @@ test('mirrors context when video transform flips horizontally', async () => {
     const call = mockDraw.mock.calls[0];
     expect(call[2]).toBe(100);
     expect(call[3]).toBe(50);
-    expect(ctx.lineWidth).toBeCloseTo(1);
   });
   spy.mockRestore();
   Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
@@ -258,7 +257,6 @@ test('scales context when rect size differs from video size', async () => {
     expect(canvas.height).toBe(100);
     expect(ctx.save).toHaveBeenCalled();
     expect(ctx.scale).toHaveBeenCalledWith(0.5, 0.5);
-    expect(ctx.lineWidth).toBeCloseTo(4);
   });
   Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
     configurable: true,

--- a/frontend/src/__tests__/poseDrawing.test.tsx
+++ b/frontend/src/__tests__/poseDrawing.test.tsx
@@ -54,3 +54,10 @@ test('edges list matches 17-point skeleton', () => {
   ];
   expect(EDGES).toEqual(expected);
 });
+
+test('drawSkeleton sets line width based on transform scale', () => {
+  const ctx = makeCtx();
+  ctx.getTransform = () => ({ a: 0.5 } as DOMMatrix);
+  drawSkeleton(ctx, [], 100, 100);
+  expect(ctx.lineWidth).toBeCloseTo(4);
+});

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -100,7 +100,6 @@ const PoseViewer: React.FC = () => {
     const sx = canvas.width / video.videoWidth;
     const sy = canvas.height / video.videoHeight;
     ctx.scale(sx, sy);
-    ctx.lineWidth = 2 / sx;
     const transform = getComputedStyle(video).transform;
     if (transform.startsWith('matrix(-1')) {
       ctx.translate(video.videoWidth, 0);


### PR DESCRIPTION
## Summary
- remove lineWidth from PoseViewer
- verify lineWidth scaling in drawSkeleton tests
- adjust PoseViewer tests for new behavior
- document the change in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687cfe5f5cf88325b442d1a4a373127d