### PR TITLE
Fix closing brace in pose drawing test

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1584,3 +1584,11 @@ TODO logs the task.
 - **Stage**: implementation
 - **Motivation / Decision**: ensure overlay drawing works after `ctx.scale(-1,1)`.
 - **Next step**: none.
+
+### 2025-07-21  PR #-
+
+- **Summary**: fixed missing closing brace in `poseDrawing.test.tsx` so tests run.
+- **Stage**: maintenance
+- **Motivation / Decision**: previous refactor left an unclosed test block which
+  broke Jest output.
+- **Next step**: none.

--- a/frontend/src/__tests__/poseDrawing.test.tsx
+++ b/frontend/src/__tests__/poseDrawing.test.tsx
@@ -60,6 +60,7 @@ test('drawSkeleton sets line width based on transform scale', () => {
   ctx.getTransform = () => ({ a: 0.5 } as DOMMatrix);
   drawSkeleton(ctx, [], 100, 100);
   expect(ctx.lineWidth).toBeCloseTo(4);
+});
 
 test('lineWidth remains positive when context is mirrored', () => {
   const ctx = makeCtx();


### PR DESCRIPTION
## Summary
- close `drawSkeleton` line width test
- add maintenance entry

## Testing
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687ddc9bec488325aafcc4e1d600a732