### PR TITLE
Add FPS metric to PoseViewer UI

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1592,3 +1592,11 @@ TODO logs the task.
 - **Motivation / Decision**: previous refactor left an unclosed test block which
   broke Jest output.
 - **Next step**: none.
+
+### 2025-07-21  PR #205
+
+- **Summary**: MetricsPanel now displays FPS and PoseViewer ensures fps is present.
+- **Stage**: implementation
+- **Motivation / Decision**: expose streaming rate for monitoring.
+  Added defaulting logic.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -186,3 +186,4 @@
       `PoseViewer`. Add test for scale handling.
 - [x] Use absolute scale from `getTransform` in `drawSkeleton` and ensure
       positive line width.
+- [x] Display FPS metric in MetricsPanel.

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,4 +53,5 @@ Balance: 0.85
 Pose: standing
 Knee Angle: 160.00°
 Posture: 30.00°
+FPS: 25.00
 ```

--- a/frontend/src/__tests__/MetricsPanel.test.tsx
+++ b/frontend/src/__tests__/MetricsPanel.test.tsx
@@ -10,6 +10,7 @@ test('displays balance, pose, knee and posture angle', () => {
         pose_class: 'standing',
         knee_angle: 45.5,
         posture_angle: 30.0,
+        fps: 20,
       }}
     />,
   );
@@ -17,4 +18,5 @@ test('displays balance, pose, knee and posture angle', () => {
   expect(screen.getByText(/Pose: standing/)).toBeInTheDocument();
   expect(screen.getByText(/Knee Angle: 45\.50°/)).toBeInTheDocument();
   expect(screen.getByText(/Posture: 30\.00°/)).toBeInTheDocument();
+  expect(screen.getByText(/FPS: 20\.00/)).toBeInTheDocument();
 });

--- a/frontend/src/__tests__/PoseViewer.test.tsx
+++ b/frontend/src/__tests__/PoseViewer.test.tsx
@@ -181,7 +181,7 @@ test('mirrors context when video transform flips horizontally', async () => {
   fireEvent(video, new Event('loadedmetadata'));
   resizeCb([] as any, {} as ResizeObserver);
   require('@testing-library/react').act(() => {
-    setPose({ landmarks: [], metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0 } });
+    setPose({ landmarks: [], metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0, fps: 0 } });
   });
   await waitFor(() => {
     expect(ctx.translate).toHaveBeenCalledWith(100, 0);
@@ -250,7 +250,7 @@ test('scales context when rect size differs from video size', async () => {
   fireEvent(video, new Event('loadedmetadata'));
   resizeCb([] as any, {} as ResizeObserver);
   require('@testing-library/react').act(() => {
-    setPose({ landmarks: [], metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0 } });
+    setPose({ landmarks: [], metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0, fps: 0 } });
   });
   await waitFor(() => {
     expect(canvas.width).toBe(200);
@@ -373,7 +373,7 @@ test('sends frames over WebSocket', async () => {
   fireEvent(video, new Event('loadedmetadata'));
   resizeCb([] as any, {} as ResizeObserver);
   require('@testing-library/react').act(() => {
-    setPose({ landmarks: [], metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0 } });
+    setPose({ landmarks: [], metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0, fps: 0 } });
   });
   jest.advanceTimersByTime(100);
   expect(ctx.save).toHaveBeenCalled();
@@ -384,7 +384,7 @@ test('sends frames over WebSocket', async () => {
   rect.height = 2;
   resizeCb([] as any, {} as ResizeObserver);
   require('@testing-library/react').act(() => {
-    setPose({ landmarks: [], metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0 } });
+    setPose({ landmarks: [], metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0, fps: 0 } });
   });
   jest.advanceTimersByTime(100);
   expect(canvas.width).toBe(4);

--- a/frontend/src/components/MetricsPanel.tsx
+++ b/frontend/src/components/MetricsPanel.tsx
@@ -3,6 +3,7 @@ export interface PoseMetrics {
   pose_class: string;
   knee_angle: number;
   posture_angle: number;
+  fps: number;
   [key: string]: number | string;
 }
 
@@ -15,12 +16,14 @@ const MetricsPanel: React.FC<MetricsPanelProps> = ({ data }) => {
   const pose = data?.pose_class ?? '';
   const knee = Number(data?.knee_angle ?? 0);
   const posture = Number(data?.posture_angle ?? 0);
+  const fps = Number(data?.fps ?? 0);
   return (
     <div className="metrics-panel">
       <p>Balance: {balance.toFixed(2)}</p>
       <p>Pose: {pose}</p>
       <p>Knee Angle: {knee.toFixed(2)}°</p>
       <p>Posture: {posture.toFixed(2)}°</p>
+      <p>FPS: {fps.toFixed(2)}</p>
     </div>
   );
 };

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -109,11 +109,15 @@ const PoseViewer: React.FC = () => {
     ctx.restore();
   }, [poseData]);
 
+  const metrics: PoseMetrics | undefined = poseData
+    ? { ...poseData.metrics, fps: Number((poseData.metrics as any).fps ?? 0) }
+    : undefined;
+
   return (
     <div className="pose-container">
       <video ref={videoRef} autoPlay muted />
       <canvas ref={canvasRef} />
-      <MetricsPanel data={poseData?.metrics} />
+      <MetricsPanel data={metrics} />
       {error && <div className="ws-error">Error: {error}</div>}
       {cameraError && (
         <div className="camera-error">Error: {cameraError}</div>


### PR DESCRIPTION
## Summary
- track fps in PoseMetrics and show it in MetricsPanel
- forward fps value from PoseViewer
- cover fps rendering in tests
- adjust PoseViewer tests
- document fps metric in docs
- log the enhancement
- tick TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687de7a1121c8325b1026d084b1364db