### PR TITLE
Render metrics panel below pose container

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1614,3 +1614,11 @@ TODO logs the task.
 - **Motivation / Decision**: playsInline allows autoplay on mobile and the
   overlay class simplifies styling.
 - **Next step**: none.
+
+### 2025-07-21
+
+- **Summary**: moved MetricsPanel below pose-container and clarified README.
+  Built frontend.
+- **Stage**: implementation
+- **Motivation / Decision**: show metrics as sibling element so layout is clearer.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ video size and flips horizontally if the video is mirrored. The
 surrounding
 
 `.pose-container` is styled so the canvas and video stack on top of each other.
-The container does not set a fixed height so the metrics panel renders below
-the video overlay.
+`MetricsPanel` is rendered as a sibling after this container so the metrics list
+appears below the video overlay.
 The `useWebSocket` hook returns the latest pose data and a connection state
 (`connecting`, `open`, `closed` or `error`). PoseViewer displays this state so
 you know if the backend is reachable. The hook accepts optional `host` and
@@ -180,9 +180,9 @@ contain an `error` field; the hook exposes this via an `error` property and
 leaves the pose data unchanged so the UI can show the problem.
 
 If webcam access is denied the viewer now reports "Webcam access denied" next
-to the connection status. The metrics panel below the video displays the
-Balance, Pose, Knee Angle, Posture and FPS metrics on separate lines for
-clarity.
+to the connection status. The metrics panel rendered after `.pose-container`
+displays the Balance, Pose, Knee Angle, Posture and FPS metrics on separate
+lines for clarity.
 
 ## Running locally
 

--- a/TODO.md
+++ b/TODO.md
@@ -189,3 +189,4 @@
 - [x] Display FPS metric in MetricsPanel.
 - [x] Add FPS metric to backend payload and display it.
 - [x] Add `playsInline` to the video element and an `.overlay` canvas class.
+- [x] Move MetricsPanel outside `.pose-container` to display below the video.

--- a/docs/tech-challenge.txt
+++ b/docs/tech-challenge.txt
@@ -184,11 +184,13 @@ const PoseViewer: React.FC = () => {
   };
 
   return (
-    <div className="pose-container">
-      <video ref={videoRef} />
-      <canvas ref={canvasRef} />
+    <>
+      <div className="pose-container">
+        <video ref={videoRef} />
+        <canvas ref={canvasRef} />
+      </div>
       <MetricsPanel data={poseData} />
-    </div>
+    </>
   );
 };
 ```

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -114,9 +114,11 @@ const PoseViewer: React.FC = () => {
     : undefined;
 
   return (
-    <div className="pose-container">
-      <video ref={videoRef} autoPlay muted playsInline />
-      <canvas ref={canvasRef} className="overlay" />
+    <>
+      <div className="pose-container">
+        <video ref={videoRef} autoPlay muted playsInline />
+        <canvas ref={canvasRef} className="overlay" />
+      </div>
       <MetricsPanel data={metrics} />
       {error && <div className="ws-error">Error: {error}</div>}
       {cameraError && (
@@ -136,7 +138,7 @@ const PoseViewer: React.FC = () => {
       >
         {streaming ? 'Stop Webcam' : 'Start Webcam'}
       </button>
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- show `MetricsPanel` after the `.pose-container` div
- rebuild the frontend bundle
- clarify the layout in README and tech notes
- log the change in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687df52fb5a48325b679cf7334331ca0