### PR TITLE
Expose pose model info

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1639,3 +1639,10 @@ TODO logs the task.
 - **Motivation / Decision**: expose client-side performance metrics for easier
   debugging and monitoring.
 - **Next step**: none.
+
+### 2025-07-21  PR #211
+
+- **Summary**: exposed model complexity via constant, WebSocket payload and UI.
+- **Stage**: implementation
+- **Motivation / Decision**: allow frontends to know if lite or full model runs.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ a dictionary with ``x``, ``y`` and ``visibility``. The keypoints are ordered as
 ``left_wrist``, ``right_wrist``, ``left_hip``, ``right_hip``, ``left_knee``,
 ``right_knee``, ``left_ankle`` and ``right_ankle``. The payload also includes
 simple analytics like knee angle, balance, a posture angle, an ``fps`` value,
-``infer_ms`` and ``json_ms`` timings and a ``pose_class`` field indicating
-``standing`` or ``sitting``.
+``infer_ms`` and ``json_ms`` timings, the ``model`` string (``lite`` or ``full``)
+and a ``pose_class`` field indicating ``standing`` or ``sitting``.
 
 ## Development
 

--- a/TODO.md
+++ b/TODO.md
@@ -193,3 +193,4 @@
 - [x] Add infer_ms and json_ms timing metrics to backend payload.
 - [x] Measure client encode/draw times and show encodeMs, sizeKB, drawMs,
       clientFps and droppedFrames in MetricsPanel.
+- [x] Include model complexity string in WebSocket payload and UI.

--- a/backend/pose_detector.py
+++ b/backend/pose_detector.py
@@ -27,9 +27,14 @@ class PoseDetector:
         mp.solutions.pose.PoseLandmark.RIGHT_ANKLE,
     ]
 
+    # 0 selects the lightweight model, 1 the full model
+    MODEL_COMPLEXITY = 1
+
     def __init__(self) -> None:
         # static_image_mode=False improves performance in video streams
-        self._pose = mp.solutions.pose.Pose(model_complexity=1, static_image_mode=False)
+        self._pose = mp.solutions.pose.Pose(
+            model_complexity=self.MODEL_COMPLEXITY, static_image_mode=False
+        )
 
     def process(self, frame: np.ndarray) -> list[dict[str, float]]:
         """Return 17 keypoints as dicts with x, y and visibility."""

--- a/backend/server.py
+++ b/backend/server.py
@@ -34,7 +34,9 @@ def build_payload(points: List[Dict[str, float]], fps: float) -> Dict[str, Any]:
     """Return WebSocket payload from 17 keypoints and frame rate."""
     metrics = extract_pose_metrics(_to_named(points))
     metrics["fps"] = fps
-    return {"landmarks": points, "metrics": metrics}
+    complexity = getattr(PoseDetector, "MODEL_COMPLEXITY", 1)
+    model = "lite" if complexity == 0 else "full"
+    return {"landmarks": points, "metrics": metrics, "model": model}
 
 
 async def _process(det: PoseDetector, data: bytes) -> list[dict[str, float]]:

--- a/frontend/src/__tests__/MetricsPanel.test.tsx
+++ b/frontend/src/__tests__/MetricsPanel.test.tsx
@@ -16,6 +16,7 @@ test('displays all metrics', () => {
         drawMs: 8,
         clientFps: 15,
         droppedFrames: 2,
+        model: 'lite',
       }}
     />,
   );
@@ -29,4 +30,5 @@ test('displays all metrics', () => {
   expect(screen.getByText(/Draw: 8\.00 ms/)).toBeInTheDocument();
   expect(screen.getByText(/Client FPS: 15\.00/)).toBeInTheDocument();
   expect(screen.getByText(/Dropped Frames: 2/)).toBeInTheDocument();
+  expect(screen.getByText(/Model: lite/)).toBeInTheDocument();
 });

--- a/frontend/src/components/MetricsPanel.tsx
+++ b/frontend/src/components/MetricsPanel.tsx
@@ -9,6 +9,7 @@ export interface PoseMetrics {
   drawMs?: number;
   clientFps?: number;
   droppedFrames?: number;
+  model?: string;
   [key: string]: number | string | undefined;
 }
 
@@ -27,6 +28,7 @@ const MetricsPanel: React.FC<MetricsPanelProps> = ({ data }) => {
   const drawMs = Number(data?.drawMs ?? 0);
   const clientFps = Number(data?.clientFps ?? 0);
   const droppedFrames = Number(data?.droppedFrames ?? 0);
+  const model = data?.model ?? '';
   return (
     <div className="metrics-panel">
       <p>Balance: {balance.toFixed(2)}</p>
@@ -39,6 +41,7 @@ const MetricsPanel: React.FC<MetricsPanelProps> = ({ data }) => {
       <p>Draw: {drawMs.toFixed(2)} ms</p>
       <p>Client FPS: {clientFps.toFixed(2)}</p>
       <p>Dropped Frames: {droppedFrames}</p>
+      <p>Model: {model}</p>
     </div>
   );
 };

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -7,6 +7,7 @@ import MetricsPanel, { PoseMetrics } from './MetricsPanel';
 interface PoseData {
   landmarks: Point[];
   metrics: PoseMetrics;
+  model: string;
 }
 
 const PoseViewer: React.FC = () => {
@@ -156,6 +157,7 @@ const PoseViewer: React.FC = () => {
         drawMs,
         clientFps,
         droppedFrames,
+        model: poseData.model,
       }
     : undefined;
 

--- a/tests/backend/test_pose_detector.py
+++ b/tests/backend/test_pose_detector.py
@@ -102,3 +102,11 @@ def test_init_sets_static_image_mode_false(monkeypatch):
     monkeypatch.setattr(mp.solutions.pose, "Pose", InspectPose)
     pd.PoseDetector()
     assert InspectPose.kwargs.get("static_image_mode") is False
+
+
+def test_init_uses_model_complexity_constant(monkeypatch):
+    monkeypatch.setattr(mp.solutions.pose, "Pose", InspectPose)
+    pd.PoseDetector()
+    assert (
+        InspectPose.kwargs.get("model_complexity") == pd.PoseDetector.MODEL_COMPLEXITY
+    )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -23,6 +23,7 @@ def test_build_payload_format():
         "posture_angle",
     } <= metrics.keys()
     assert "fps" in metrics
+    assert payload["model"] in ("lite", "full")
 
 
 def test_names_match_landmarks():


### PR DESCRIPTION
## Summary
- add `MODEL_COMPLEXITY` constant
- include `model` in WebSocket payload
- show model string in MetricsPanel
- document WebSocket payload
- update tests

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687e08a84e3c832591a46dc84687e0a3