### PR TITLE
Align timestamp metrics to epoch

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1689,3 +1689,10 @@ TODO logs the task.
   averages.
 - **Stage**: implementation
 - **Motivation / Decision**: monitor backend resource usage and fulfil TODO.
+
+### 2025-07-24  PR #218
+
+- **Summary**: switched frame timestamps to epoch using Date.now()/time.time.
+- **Stage**: implementation
+- **Motivation / Decision**: align client-server clocks for accurate network metrics.
+- **Next step**: none.

--- a/backend/server.py
+++ b/backend/server.py
@@ -102,10 +102,11 @@ async def pose_endpoint(ws: WebSocket) -> None:
 
             ts_send = struct.unpack("<d", data[:8])[0]
             frame_bytes = data[8:]
-            ts_recv_ms = time.perf_counter() * 1000.0
+            ts_recv_ms = time.time() * 1000.0
+            ts_recv_perf = time.perf_counter()
             try:
                 start_infer = time.perf_counter()
-                wait_ms = start_infer * 1000.0 - ts_recv_ms
+                wait_ms = (start_infer - ts_recv_perf) * 1000.0
                 points = await _process(detector, frame_bytes)
                 infer_ms = (time.perf_counter() - start_infer) * 1000.0
                 uplink_ms = ts_recv_ms - ts_send
@@ -137,7 +138,7 @@ async def pose_endpoint(ws: WebSocket) -> None:
                     "json_ms": json_ms,
                     "uplink_ms": uplink_ms,
                     "wait_ms": wait_ms,
-                    "ts_out": time.perf_counter(),
+                    "ts_out": time.time(),
                 }
             )
             try:

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -44,7 +44,7 @@ const PoseViewer: React.FC = () => {
         return;
       }
       encodePending.current = true;
-      const start = performance.now();
+          const start = performance.now();
       off.width = video.videoWidth;
       off.height = video.videoHeight;
       ctx.drawImage(video, 0, 0, off.width, off.height);
@@ -54,7 +54,7 @@ const PoseViewer: React.FC = () => {
           setEncodeMs(end - start);
           if (b) {
             setSizeKB(b.size / 1024);
-            const ts = performance.now();
+            const ts = Date.now();
             tsSendRef.current = ts;
             const buf = new ArrayBuffer(8 + b.size);
             new DataView(buf).setFloat64(0, ts, true);
@@ -149,7 +149,7 @@ const PoseViewer: React.FC = () => {
     if (!canvas || !video || !poseData) return;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
-    const recv = performance.now();
+    const recv = Date.now();
     const tsOut = Number((poseData.metrics as any).ts_out ?? 0);
     setDownlinkMs(recv - tsOut * 1000);
     const start = recv;
@@ -168,7 +168,7 @@ const PoseViewer: React.FC = () => {
     ctx.restore();
     const end = performance.now();
     setDrawMs(end - start);
-    setLatencyMs(end - tsSendRef.current);
+    setLatencyMs(Date.now() - tsSendRef.current);
   }, [poseData]);
 
   const metrics: PoseMetrics | undefined = poseData

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -250,14 +250,12 @@ def test_fps_metric_updates(monkeypatch):
         1.10,  # now 1
         1.12,  # start_json 1
         1.14,  # end_json 1
-        1.16,  # ts_out 1
         1.20,  # ts_recv 2
         1.22,  # start_infer 2
         1.24,  # end_infer 2
         1.30,  # now 2
         1.32,  # start_json 2
         1.34,  # end_json 2
-        1.36,  # ts_out 2
     ]
 
     def fake_perf_counter() -> float:
@@ -289,25 +287,32 @@ def test_timestamp_metrics(monkeypatch):
         def process(self, image: Any) -> list[Any]:
             return [{"x": 0.0, "y": 0.0}] * 17
 
-    times = [
+    perf_times = [
         0.0,  # initial last_time
-        1.0,  # ts_recv
+        1.0,  # ts_recv_perf
         1.05,  # start_infer
         1.10,  # end_infer
         1.20,  # now
         1.25,  # start_json
         1.26,  # end_json
-        1.27,  # ts_out
+    ]
+    wall_times = [
+        1000.0,  # ts_recv_ms
+        1000.27,  # ts_out
     ]
 
     def fake_perf_counter() -> float:
-        return times.pop(0)
+        return perf_times.pop(0)
+
+    def fake_time() -> float:
+        return wall_times.pop(0)
 
     monkeypatch.setattr(server.time, "perf_counter", fake_perf_counter)
+    monkeypatch.setattr(server.time, "time", fake_time)
     monkeypatch.setattr(server, "PoseDetector", lambda *_a, **_k: Pose())
     frame = np.zeros((1, 1, 3), dtype=np.uint8)
     _, buf = server.cv2.imencode(".jpg", frame)
-    ts_send = 100.0
+    ts_send = 999000.0
     data = struct.pack("<d", ts_send) + buf.tobytes()
     ws = DummyWS([data])
 
@@ -315,8 +320,8 @@ def test_timestamp_metrics(monkeypatch):
 
     payload = json.loads(ws.sent[0])
     m = payload["metrics"]
-    assert abs(m["uplink_ms"] - (1000.0 - ts_send)) < 1e-6
+    assert abs(m["uplink_ms"] - (1000000.0 - ts_send)) < 1e-6
     assert abs(m["wait_ms"] - 50.0) < 1e-6
-    assert abs(m["ts_out"] - 1.27) < 1e-6
+    assert abs(m["ts_out"] - 1000.27) < 1e-6
     assert "cpu_percent" in m
     assert "rss_bytes" in m


### PR DESCRIPTION
## Summary
- send frame timestamps using `Date.now()` in PoseViewer
- measure `ts_recv_ms` and `ts_out` with `time.time()` in backend
- update timestamp metric tests to use epoch values
- log work about epoch timestamps

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687e15f2077c8325abef023829e2c4d8