### PR TITLE
Require future annotations in tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.49 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.50 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -301,6 +301,8 @@ jobs:
 - Use a normal space after `#` in headings.
 - Avoid bare URLs; format them as Markdown links (MD034).
 - Avoid inline HTML.
+- All Python modules, including tests, must start with
+  `from __future__ import annotations` so union types work on Python 3.9.
 
 ---
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1689,3 +1689,12 @@ TODO logs the task.
   averages.
 - **Stage**: implementation
 - **Motivation / Decision**: monitor backend resource usage and fulfil TODO.
+
+### 2025-07-24  PR #218
+
+- **Summary**: inserted `from __future__ import annotations` in tests and
+  updated style guide.
+- **Stage**: maintenance
+- **Motivation / Decision**: union types require the future import on
+  Python 3.9; tests were missing it.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -197,3 +197,5 @@
 - [x] Track uplink, wait, downlink and latency using frame timestamps and show
       these metrics in the UI.
 - [x] Add CPU and memory usage metrics using optional psutil.
+- [x] Ensure all Python modules start with `from __future__ import annotations`
+      for Python 3.9 support.

--- a/tests/test_powershell_wrappers.py
+++ b/tests/test_powershell_wrappers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import shutil
 import subprocess

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 from backend.server import build_payload
 import backend.server as server


### PR DESCRIPTION
## Summary
- make Coding Style require `from __future__ import annotations`
- add the future import to `tests/test_server.py`
- add the future import to `tests/test_powershell_wrappers.py`
- mark roadmap item about the import done
- record the change in `NOTES.md`

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`
- `python -m pre_commit run --files AGENTS.md NOTES.md TODO.md tests/test_powershell_wrappers.py tests/test_server.py`

------
https://chatgpt.com/codex/tasks/task_e_687e17b08a288325abc1c3ac7b744ffc