### PR TITLE
Update coding rule for duration timing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.50 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.51 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -303,6 +303,8 @@ jobs:
 - Avoid inline HTML.
 - All Python modules, including tests, must start with
   `from __future__ import annotations` so union types work on Python 3.9.
+- Use the same clock source for all duration measurements; in browsers call
+  `performance.now()`.
 
 ---
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1716,3 +1716,10 @@ TODO logs the task.
 - **Stage**: documentation
 - **Motivation / Decision**: clarify metrics displayed in the UI.
 - **Next step**: none.
+
+### 2025-07-25  PR #222
+
+- **Summary**: added rule requiring consistent clock source for duration measurement.
+- **Stage**: documentation
+- **Motivation / Decision**: avoid inconsistent timings; align coding guidelines.
+- **Next step**: none.


### PR DESCRIPTION
## Summary
- bump AGENTS guide version
- note consistent clock source in coding rules
- record update in NOTES

## Testing
- `make lint-docs`
- `pre-commit run --files AGENTS.md NOTES.md`


------
https://chatgpt.com/codex/tasks/task_e_687e219206288325890bb63d29acd9e3