### PR TITLE
Fix pymake subdirectory test

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1716,3 +1716,11 @@ TODO logs the task.
 - **Stage**: documentation
 - **Motivation / Decision**: clarify metrics displayed in the UI.
 - **Next step**: none.
+
+### 2025-07-25  PR #222
+
+- **Summary**: patched `test_pymake_works_from_subdirectory` to mock PowerShell
+  detection.
+- **Stage**: testing
+- **Motivation / Decision**: make test deterministic regardless of installed
+  executables.

--- a/TODO.md
+++ b/TODO.md
@@ -200,3 +200,5 @@
 - [x] Ensure all Python modules start with `from __future__ import annotations`
       for Python 3.9 support.
 - [x] Strip comments in parse_requirements to avoid false version mismatches.
+- [x] Ensure `test_pymake_works_from_subdirectory` stubs shutil.which for
+      deterministic behavior.

--- a/tests/test_pymake.py
+++ b/tests/test_pymake.py
@@ -101,6 +101,7 @@ def test_pymake_works_from_subdirectory(tmp_path, monkeypatch):
         return 0
 
     monkeypatch.setattr(pymake, "os", types.SimpleNamespace(name="nt"))
+    monkeypatch.setattr(pymake.shutil, "which", lambda exe: None)
     monkeypatch.setattr(subprocess, "call", fake_call)
     ret = pymake.main(["lint"])
     expected = [


### PR DESCRIPTION
## Summary
- ensure `test_pymake_works_from_subdirectory` stubs PowerShell lookup
- record change in TODO and NOTES

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687e21b27ce08325b1887b2218fcde3d