### PR TITLE
Add average FPS metric

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1716,3 +1716,9 @@ TODO logs the task.
 - **Stage**: documentation
 - **Motivation / Decision**: clarify metrics displayed in the UI.
 - **Next step**: none.
+
+### 2025-07-25
+
+- **Summary**: backend and docs expose average FPS metric `fps_avg`.
+- **Stage**: implementation
+- **Motivation / Decision**: provide smoother FPS reporting over a 30-frame window.

--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ a dictionary with ``x``, ``y`` and ``visibility``. The keypoints are ordered as
 ``left_shoulder``, ``right_shoulder``, ``left_elbow``, ``right_elbow``,
 ``left_wrist``, ``right_wrist``, ``left_hip``, ``right_hip``, ``left_knee``,
 ``right_knee``, ``left_ankle`` and ``right_ankle``. The payload also includes
-simple analytics like knee angle, balance, a posture angle, an ``fps`` value,
-``infer_ms`` and ``json_ms`` timings, the ``model`` string (``lite`` or ``full``)
-and a ``pose_class`` field indicating ``standing`` or ``sitting``.
+simple analytics like knee angle, balance, a posture angle, ``fps`` and
+``fps_avg`` values, ``infer_ms`` and ``json_ms`` timings, the ``model`` string
+(``lite`` or ``full``) and a ``pose_class`` field indicating ``standing`` or
+``sitting``.
 
 ## Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,9 +32,9 @@ metrics = extract_pose_metrics(landmarks)
 
 The returned dictionary contains ``knee_angle`` in degrees,
 ``balance`` between the hips, ``posture_angle`` and ``pose_class``.
-It also includes an ``fps`` metric for the current frame rate. When ``psutil``
-is installed the dictionary adds ``cpu_percent`` and ``rss_bytes`` for process
-usage statistics.
+It also includes ``fps`` and ``fps_avg`` metrics for the current and average
+frame rate. When ``psutil`` is installed the dictionary adds ``cpu_percent`` and
+``rss_bytes`` for process usage statistics.
 
 Start the backend server with:
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,7 +14,7 @@ import struct
 
 def test_build_payload_format():
     lms = [{"x": 0.1, "y": 0.2, "visibility": 0.9}] * 17
-    payload = build_payload(lms, 30.0)
+    payload = build_payload(lms, 30.0, 30.0)
     assert isinstance(payload["landmarks"], list)
     assert len(payload["landmarks"]) == 17
     assert payload["landmarks"][0]["x"] == 0.1
@@ -26,6 +26,7 @@ def test_build_payload_format():
         "posture_angle",
     } <= metrics.keys()
     assert "fps" in metrics
+    assert "fps_avg" in metrics
     assert "cpu_percent" in metrics
     assert "rss_bytes" in metrics
     assert payload["model"] in ("lite", "full")
@@ -273,15 +274,19 @@ def test_fps_metric_updates(monkeypatch):
 
     payloads = [json.loads(msg) for msg in ws.sent]
     fps_values = [p["metrics"]["fps"] for p in payloads]
+    fps_avg_values = [p["metrics"]["fps_avg"] for p in payloads]
     assert len(fps_values) == 2
     assert abs(fps_values[0] - 10.0) < 1e-6
     assert abs(fps_values[1] - 5.0) < 1e-6
+    assert abs(fps_avg_values[0] - 10.0) < 1e-6
+    assert abs(fps_avg_values[1] - (2 / 0.30)) < 1e-6
     for p in payloads:
         m = p["metrics"]
         assert "infer_ms" in m
         assert "json_ms" in m
         assert "cpu_percent" in m
         assert "rss_bytes" in m
+        assert "fps_avg" in m
 
 
 def test_timestamp_metrics(monkeypatch):
@@ -327,3 +332,4 @@ def test_timestamp_metrics(monkeypatch):
     assert abs(m["ts_out"] - 1000.27) < 1e-6
     assert "cpu_percent" in m
     assert "rss_bytes" in m
+    assert "fps_avg" in m


### PR DESCRIPTION
## Summary
- compute running FPS average in backend and send as `fps_avg`
- update server tests to assert `fps_avg` values
- document `fps_avg` in README and docs
- record the change in NOTES

## Testing
- `make lint`
- `make typecheck`
- `make test`
- `pre-commit run --files backend/server.py tests/test_server.py README.md docs/README.md NOTES.md TODO.md`

------
https://chatgpt.com/codex/tasks/task_e_687e219076cc83259f85ac7a145b290a