### PR TITLE
Fix negative draw timing

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1716,3 +1716,11 @@ TODO logs the task.
 - **Stage**: documentation
 - **Motivation / Decision**: clarify metrics displayed in the UI.
 - **Next step**: none.
+
+### 2025-07-25  PR #222
+
+- **Summary**: fixed negative drawMs by using performance.now() for start and end.
+- **Stage**: implementation
+- **Motivation / Decision**: performance.now and Date.now were mixed causing
+  negative timing; use one source for reliability.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -200,3 +200,4 @@
 - [x] Ensure all Python modules start with `from __future__ import annotations`
       for Python 3.9 support.
 - [x] Strip comments in parse_requirements to avoid false version mismatches.
+- [x] Record draw time with performance.now to prevent negative values.

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -152,7 +152,7 @@ const PoseViewer: React.FC = () => {
     const recv = Date.now();
     const tsOut = Number((poseData.metrics as any).ts_out ?? 0);
     setDownlinkMs(recv - tsOut * 1000);
-    const start = recv;
+    const start = performance.now();
     ctx.save();
     ctx.setTransform(1, 0, 0, 1, 0, 0);
     ctx.clearRect(0, 0, canvas.width, canvas.height);


### PR DESCRIPTION
## Summary
- fix draw timing by recording start and end with `performance.now`
- test PoseViewer draws with non-negative time
- document fix in NOTES and TODO

## Testing
- `make lint`
- `make typecheck-ts`
- `make test`
- `python -m pre_commit run --files frontend/src/components/PoseViewer.tsx frontend/src/__tests__/PoseViewer.test.tsx NOTES.md TODO.md`


------
https://chatgpt.com/codex/tasks/task_e_687e218f897483258c710a77711a4db6