### PR TITLE
Add decode_ms metric

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1716,3 +1716,10 @@ TODO logs the task.
 - **Stage**: documentation
 - **Motivation / Decision**: clarify metrics displayed in the UI.
 - **Next step**: none.
+
+### 2025-07-25  PR #222
+
+- **Summary**: added decode_ms metric timing cv2.imdecode;
+  frontend and docs show it.
+- **Stage**: implementation
+- **Motivation / Decision**: track image decode cost for performance insight.

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ leaves the pose data unchanged so the UI can show the problem.
 If webcam access is denied the viewer now reports "Webcam access denied" next
 to the connection status. The metrics panel below `.pose-container` lists
 balance, pose, knee angle, posture angle, FPS, infer and JSON times, encode
-time, blob size, draw time, uplink and wait times, downlink delay, latency,
+time, decode time, blob size, draw time, uplink and wait times, downlink delay, latency,
 client FPS, dropped frames and the model name. When `psutil` is installed
 CPU and memory usage also appear.
 

--- a/TODO.md
+++ b/TODO.md
@@ -200,3 +200,4 @@
 - [x] Ensure all Python modules start with `from __future__ import annotations`
       for Python 3.9 support.
 - [x] Strip comments in parse_requirements to avoid false version mismatches.
+- [x] Measure decode_ms for cv2.imdecode and expose metric in UI.

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,8 +49,9 @@ performance with continuous frames.
 
 The React frontend displays these metrics below the video feed in a vertical
 list for readability. Each line shows balance, pose, knee angle, posture angle,
-FPS, infer and JSON times, encode time, blob size, draw time, uplink and wait
-times, downlink delay, end-to-end latency, client FPS, dropped frames and the
+FPS, infer and JSON times, decode time, encode time, blob size, draw time,
+uplink and wait times, downlink delay, end-to-end latency, client FPS,
+dropped frames and the
 model name. When `psutil` is installed the panel also shows CPU and memory
 usage. When connected you might see text like:
 
@@ -60,6 +61,7 @@ Pose: standing
 Knee Angle: 160.00°
 Posture: 30.00°
 FPS: 25.00
+Decode: 3.00 ms
 Encode: 5.00 ms
 Size: 12.3 KB
 Draw: 8.00 ms

--- a/frontend/src/__tests__/MetricsPanel.test.tsx
+++ b/frontend/src/__tests__/MetricsPanel.test.tsx
@@ -13,6 +13,7 @@ test('displays all metrics', () => {
         fps: 20,
         inferMs: 6,
         jsonMs: 2,
+        decodeMs: 1,
         encodeMs: 5,
         sizeKB: 12.3,
         drawMs: 8,
@@ -35,6 +36,7 @@ test('displays all metrics', () => {
   expect(screen.getByText(/FPS: 20\.00/)).toBeInTheDocument();
   expect(screen.getByText(/Infer: 6\.00 ms/)).toBeInTheDocument();
   expect(screen.getByText(/JSON: 2\.00 ms/)).toBeInTheDocument();
+  expect(screen.getByText(/Decode: 1\.00 ms/)).toBeInTheDocument();
   expect(screen.getByText(/Encode: 5\.00 ms/)).toBeInTheDocument();
   expect(screen.getByText(/Size: 12\.3 KB/)).toBeInTheDocument();
   expect(screen.getByText(/Draw: 8\.00 ms/)).toBeInTheDocument();

--- a/frontend/src/components/MetricsPanel.tsx
+++ b/frontend/src/components/MetricsPanel.tsx
@@ -6,6 +6,7 @@ export interface PoseMetrics {
   fps: number;
   inferMs?: number;
   jsonMs?: number;
+  decodeMs?: number;
   encodeMs?: number;
   sizeKB?: number;
   drawMs?: number;
@@ -33,6 +34,7 @@ const MetricsPanel: React.FC<MetricsPanelProps> = ({ data }) => {
   const fps = Number(data?.fps ?? 0);
   const inferMs = Number(data?.inferMs ?? 0);
   const jsonMs = Number(data?.jsonMs ?? 0);
+  const decodeMs = Number(data?.decodeMs ?? 0);
   const encodeMs = Number(data?.encodeMs ?? 0);
   const sizeKB = Number(data?.sizeKB ?? 0);
   const drawMs = Number(data?.drawMs ?? 0);
@@ -54,6 +56,7 @@ const MetricsPanel: React.FC<MetricsPanelProps> = ({ data }) => {
       <p>FPS: {fps.toFixed(2)}</p>
       <p>Infer: {inferMs.toFixed(2)} ms</p>
       <p>JSON: {jsonMs.toFixed(2)} ms</p>
+      <p>Decode: {decodeMs.toFixed(2)} ms</p>
       <p>Encode: {encodeMs.toFixed(2)} ms</p>
       <p>Size: {sizeKB.toFixed(1)} KB</p>
       <p>Draw: {drawMs.toFixed(2)} ms</p>

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -177,6 +177,7 @@ const PoseViewer: React.FC = () => {
         fps: Number((poseData.metrics as any).fps ?? 0),
         inferMs: Number((poseData.metrics as any).infer_ms ?? 0),
         jsonMs: Number((poseData.metrics as any).json_ms ?? 0),
+        decodeMs: Number((poseData.metrics as any).decode_ms ?? 0),
         encodeMs,
         sizeKB,
         drawMs,

--- a/tests/performance/test_server_performance.py
+++ b/tests/performance/test_server_performance.py
@@ -46,8 +46,10 @@ class DummyWS:
         self.closed = True
 
 
-async def _dummy_process(det: DummyDetector, frame: Any) -> list[dict[str, float]]:
-    return det.process(frame)
+async def _dummy_process(
+    det: DummyDetector, frame: Any
+) -> tuple[list[dict[str, float]], float]:
+    return det.process(frame), 0.0
 
 
 def test_pose_endpoint_performance(monkeypatch: Any) -> None:
@@ -73,6 +75,7 @@ def test_pose_endpoint_performance(monkeypatch: Any) -> None:
         assert "fps" in metrics
         assert "infer_ms" in metrics
         assert "json_ms" in metrics
+        assert "decode_ms" in metrics
         assert "cpu_percent" in metrics
         assert "rss_bytes" in metrics
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -248,12 +248,16 @@ def test_fps_metric_updates(monkeypatch):
         1.0,  # initial last_time
         1.01,  # ts_recv 1
         1.02,  # start_infer 1
+        1.021,  # decode_start 1
+        1.03,  # decode_end 1
         1.04,  # end_infer 1
         1.10,  # now 1
         1.12,  # start_json 1
         1.14,  # end_json 1
         1.20,  # ts_recv 2
         1.22,  # start_infer 2
+        1.221,  # decode_start 2
+        1.23,  # decode_end 2
         1.24,  # end_infer 2
         1.30,  # now 2
         1.32,  # start_json 2
@@ -280,6 +284,7 @@ def test_fps_metric_updates(monkeypatch):
         m = p["metrics"]
         assert "infer_ms" in m
         assert "json_ms" in m
+        assert "decode_ms" in m
         assert "cpu_percent" in m
         assert "rss_bytes" in m
 
@@ -293,6 +298,8 @@ def test_timestamp_metrics(monkeypatch):
         0.0,  # initial last_time
         1.0,  # ts_recv_perf
         1.05,  # start_infer
+        1.055,  # decode_start
+        1.06,  # decode_end
         1.10,  # end_infer
         1.20,  # now
         1.25,  # start_json
@@ -327,3 +334,4 @@ def test_timestamp_metrics(monkeypatch):
     assert abs(m["ts_out"] - 1000.27) < 1e-6
     assert "cpu_percent" in m
     assert "rss_bytes" in m
+    assert "decode_ms" in m


### PR DESCRIPTION
## Summary
- measure JPEG decode time in backend and return it to the client
- display decode time in the React metrics panel
- document the new metric in README and docs
- adjust tests for added field
- note the change in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`
- `pre-commit run --files NOTES.md README.md TODO.md backend/server.py docs/README.md frontend/src/__tests__/MetricsPanel.test.tsx frontend/src/components/MetricsPanel.tsx frontend/src/components/PoseViewer.tsx tests/performance/test_server_performance.py tests/test_server.py`

------
https://chatgpt.com/codex/tasks/task_e_687e2190bd1c8325ad96aba40ee4d155