### PR TITLE
Implement 20fps capture in PoseViewer

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1750,3 +1750,10 @@ TODO logs the task.
 - **Stage**: documentation
 - **Motivation / Decision**: avoid inconsistent timings; align coding guidelines.
 - **Next step**: none.
+
+### 2025-07-21  PR #227
+
+- **Summary**: reduced frame interval to 50ms in PoseViewer for smoother video.
+- **Stage**: implementation
+- **Motivation / Decision**: 20 FPS target requires faster capture; tests updated.
+- **Next step**: none.

--- a/frontend/src/__tests__/PoseViewer.test.tsx
+++ b/frontend/src/__tests__/PoseViewer.test.tsx
@@ -296,7 +296,13 @@ test('stop button closes the WebSocket', async () => {
   const { stream, getUserMedia } = mockMedia();
   mockWS.mockImplementation(() => {
     const [status, setStatus] = require('react').useState('open');
-    return { poseData: null, status: status as 'open' | 'closed', error: null, close: () => setStatus('closed') };
+    return {
+      poseData: null,
+      status: status as 'open' | 'closed',
+      error: null,
+      close: () => setStatus('closed'),
+      send: jest.fn(),
+    };
   });
   const PoseViewerMod = require('../components/PoseViewer').default;
   const { getByRole, getByText, container } = render(<PoseViewerMod />);
@@ -376,7 +382,7 @@ test('sends frames over WebSocket', async () => {
     setPose({ landmarks: [], metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0, fps: 0 } });
   });
   await require('@testing-library/react').act(async () => {
-    jest.advanceTimersByTime(100);
+    jest.advanceTimersByTime(50);
     await Promise.resolve();
   });
   expect(ctx.save).toHaveBeenCalled();
@@ -390,7 +396,7 @@ test('sends frames over WebSocket', async () => {
     setPose({ landmarks: [], metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0, fps: 0 } });
   });
   await require('@testing-library/react').act(async () => {
-    jest.advanceTimersByTime(100);
+    jest.advanceTimersByTime(50);
     await Promise.resolve();
   });
   expect(canvas.width).toBe(4);

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -89,7 +89,7 @@ const PoseViewer: React.FC = () => {
         },
         'image/jpeg',
       );
-    }, 100);
+    }, 50);
     return () => clearInterval(id);
   }, [streaming, status, send]);
 


### PR DESCRIPTION
## Summary
- capture webcam frames every 50ms instead of 100ms
- adjust PoseViewer tests for the new timing
- mock WebSocket `send` in stop button test
- record the change in NOTES

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687e2b18d3c483258b1f1d5a181700fb