### PR TITLE
Reduce PoseViewer interval to 25ms

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1757,3 +1757,10 @@ TODO logs the task.
 - **Stage**: implementation
 - **Motivation / Decision**: 20 FPS target requires faster capture; tests updated.
 - **Next step**: none.
+
+### 2025-07-21  PR #228
+
+- **Summary**: halved PoseViewer interval to 25ms for snappier streaming.
+- **Stage**: implementation
+- **Motivation / Decision**: higher 40 FPS target; updated test delays.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -203,3 +203,4 @@
 - [x] Record draw time with performance.now to prevent negative values.
 - [x] Ensure `test_pymake_works_from_subdirectory` stubs shutil.which for
       deterministic behavior.
+- [x] Reduce frame capture interval in PoseViewer to 25ms for smoother video.

--- a/frontend/src/__tests__/PoseViewer.test.tsx
+++ b/frontend/src/__tests__/PoseViewer.test.tsx
@@ -382,7 +382,7 @@ test('sends frames over WebSocket', async () => {
     setPose({ landmarks: [], metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0, fps: 0 } });
   });
   await require('@testing-library/react').act(async () => {
-    jest.advanceTimersByTime(50);
+    jest.advanceTimersByTime(25);
     await Promise.resolve();
   });
   expect(ctx.save).toHaveBeenCalled();
@@ -396,7 +396,7 @@ test('sends frames over WebSocket', async () => {
     setPose({ landmarks: [], metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0, fps: 0 } });
   });
   await require('@testing-library/react').act(async () => {
-    jest.advanceTimersByTime(50);
+    jest.advanceTimersByTime(25);
     await Promise.resolve();
   });
   expect(canvas.width).toBe(4);

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -89,7 +89,7 @@ const PoseViewer: React.FC = () => {
         },
         'image/jpeg',
       );
-    }, 50);
+    }, 25);
     return () => clearInterval(id);
   }, [streaming, status, send]);
 


### PR DESCRIPTION
## Summary
- halve PoseViewer's capture interval to improve FPS
- adjust PoseViewer tests for the faster timer
- document the change in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`
- `make lint-docs`


------
https://chatgpt.com/codex/tasks/task_e_687e2ef0910c8325b925cbb8e167c769