### PR TITLE
Update docs with Pages link and overview

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1764,3 +1764,10 @@ TODO logs the task.
 - **Stage**: implementation
 - **Motivation / Decision**: higher 40 FPS target; updated test delays.
 - **Next step**: none.
+
+### 2025-07-21  PR #229
+
+- **Summary**: linked Pages deployment, added docs overview and ticked TODO.
+- **Stage**: documentation
+- **Motivation / Decision**: show published docs and provide Sphinx overview.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ When `GH_PAGES_TOKEN` is available the workflow deploys them to GitHub Pages.
 Enable Pages in the repo settings with **GitHub Actions** as the source before
 expecting deployments.
 
+- [Deployment history on GitHub Pages](https://github.com/IvanStarostin1984/PoseDetection/deployments/github-pages)
+
 ## License
 
 PoseDetection is released under the MIT License. See [LICENSE](LICENSE).

--- a/TODO.md
+++ b/TODO.md
@@ -143,7 +143,7 @@
 - [x] Remove obsolete Jekyll Pages workflow.
 - [x] Configure Pages before uploading docs
 - [x] Document streaming toggle logic in README.
-- [ ] Enable GitHub Pages with **GitHub Actions** as the source before
+- [x] Enable GitHub Pages with **GitHub Actions** as the source before
       expecting deployments.
 - [x] Add posture angle metric in backend and frontend.
 - [x] Set `static_image_mode=False` in PoseDetector for better streaming performance.

--- a/docs/source/README.md
+++ b/docs/source/README.md
@@ -1,0 +1,74 @@
+# Documentation
+
+This project demonstrates a basic real-time human pose estimation system. The
+full assignment and requirements are listed in
+[tech-challenge.txt](tech-challenge.txt).
+
+Placeholder for project docs.
+
+The pose detector outputs 17 landmarks in the following order:
+``nose``, ``left_eye``, ``right_eye``, ``left_ear``, ``right_ear``,
+``left_shoulder``, ``right_shoulder``, ``left_elbow``, ``right_elbow``,
+``left_wrist``, ``right_wrist``, ``left_hip``, ``right_hip``, ``left_knee``,
+``right_knee``, ``left_ankle`` and ``right_ankle``.
+
+The landmark coordinates are normalized between 0 and 1. When drawing the
+pose skeleton these values are multiplied by the video's width and height to
+obtain pixel positions.
+
+## Backend analytics
+
+The backend exposes a WebSocket endpoint at `/pose`. The browser captures
+webcam frames, encodes each one as a JPEG and sends it to this endpoint. The
+server decodes these bytes, runs `PoseDetector`, and streams pose metrics as
+JSON. The metrics are calculated in `backend/analytics.py`:
+
+```python
+from backend.analytics import extract_pose_metrics
+
+# landmarks is a dict like {'left_hip': {'x': 0.5, 'y': 0.5}, ...}
+metrics = extract_pose_metrics(landmarks)
+```
+
+The returned dictionary contains ``knee_angle`` in degrees,
+``balance`` between the hips, ``posture_angle`` and ``pose_class``.
+It also includes ``fps`` and ``fps_avg`` metrics for the current and average
+frame rate. When ``psutil`` is installed the dictionary adds ``cpu_percent`` and
+``rss_bytes`` for process usage statistics.
+
+Start the backend server with:
+
+```bash
+python -m backend.server
+```
+
+The pose detector uses `static_image_mode=False` for real-time
+performance with continuous frames.
+
+## Frontend metrics panel
+
+The React frontend displays these metrics below the video feed in a vertical
+list for readability. Each line shows balance, pose, knee angle, posture angle,
+FPS, infer and JSON times, encode time, blob size, draw time, uplink and wait
+times, downlink delay, end-to-end latency, client FPS, dropped frames and the
+model name. When `psutil` is installed the panel also shows CPU and memory
+usage. When connected you might see text like:
+
+```text
+Balance: 0.85
+Pose: standing
+Knee Angle: 160.00°
+Posture: 30.00°
+FPS: 25.00
+Encode: 5.00 ms
+Size: 12.3 KB
+Draw: 8.00 ms
+Uplink: 4.00 ms
+Wait: 1.00 ms
+Downlink: 6.00 ms
+Latency: 9.00 ms
+Client FPS: 24.00
+Dropped Frames: 0
+CPU: 80.0 %
+Mem: 120 MB
+```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,12 @@ release = "0.1"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = []
+extensions = ["myst_parser"]
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
 
 templates_path = ["_templates"]
 exclude_patterns = []

--- a/docs/source/feature_a.md
+++ b/docs/source/feature_a.md
@@ -1,0 +1,26 @@
+# Feature A Assumptions and Edge Cases
+
+This project implements the first MVP feature described in the tech challenge:
+real‑time pose detection with 17 keypoints and a simple analytics overlay.
+
+## Assumptions
+
+- A standard webcam provides frames at 20 fps or more.
+- The environment has good lighting so detection accuracy stays above 80%.
+- Clients connect via a local network to keep latency below 200 ms.
+- The backend runs on Python with FastAPI and MediaPipe Pose.
+- The frontend uses React, TypeScript and the Canvas API.
+
+## Edge cases
+
+- **Low light**: keypoints may be missing or inaccurate; the server should
+  still respond without crashing.
+- **Occluded joints**: when elbows or knees are hidden, metrics such as angles
+  may default to `None`.
+- **Slow devices**: if the webcam or CPU cannot maintain 20 fps, the client
+  may see stutter and outdated analytics.
+- **Network drop**: WebSocket connections might close unexpectedly and should
+  reconnect gracefully.
+
+These notes complement the main specification in
+[docs/tech-challenge.txt](tech-challenge.txt).

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,16 +1,16 @@
-.. PoseDetection documentation master file, created by
-   sphinx-quickstart on Mon Jul 14 10:57:30 2025.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+PoseDetection documentation
+---------------------------
 
-Welcome to PoseDetection's documentation!
-#########################################
+PoseDetection is a real-time pose estimation demo. The Python backend
+runs MediaPipe to detect 17 keypoints and streams metrics over a
+WebSocket. A React frontend draws the skeleton and lists timing and
+posture metrics.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
 
-
+   README.md
+   feature_a.md
 
 Indices and tables
 ##################

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ sphinx==7.2.6
 numpy==1.26.4
 mypy==1.16.1
 psutil==5.9.8  # optional
+myst-parser==4.0.1


### PR DESCRIPTION
## Summary
- link to GitHub Pages deployment history in README
- flesh out Sphinx index with project overview and toctree
- enable markdown pages via myst-parser
- tick TODO entry for enabling Pages

## Testing
- `make lint-docs`
- `make docs`


------
https://chatgpt.com/codex/tasks/task_e_687e3886a7088325b1856791d6d9d74a