### PR TITLE
docs: skip pages link for lychee

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1771,3 +1771,10 @@ TODO logs the task.
 - **Stage**: documentation
 - **Motivation / Decision**: show published docs and provide Sphinx overview.
 - **Next step**: none.
+
+### 2025-07-21  PR #230
+
+- **Summary**: added lychee skip comment after Pages deployment link.
+- **Stage**: documentation
+- **Motivation / Decision**: ensure link checker passes for remote URL.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ When `GH_PAGES_TOKEN` is available the workflow deploys them to GitHub Pages.
 Enable Pages in the repo settings with **GitHub Actions** as the source before
 expecting deployments.
 
-- [Deployment history on GitHub Pages](https://github.com/IvanStarostin1984/PoseDetection/deployments/github-pages)
+<!-- markdownlint-disable-next-line MD013 -->
+- [Deployment history on GitHub Pages](https://github.com/IvanStarostin1984/PoseDetection/deployments/github-pages) <!-- lychee skip -->
 
 ## License
 


### PR DESCRIPTION
## Summary
- add lychee skip comment for deployment history link
- note the change in NOTES

## Testing
- `make lint-docs`


------
https://chatgpt.com/codex/tasks/task_e_687e3e4c96f8832589cc14af4d7c2c9c