### PR TITLE
docs: clarify lychee skip usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.51 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.52 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -277,6 +277,9 @@ jobs:
 - Use `<!-- lychee skip -->` after local URLs (e.g. `http://localhost:`)
   so lychee doesn’t fail. Localhost patterns are also
   ignored via `.lycheeignore`.
+- For links to resources that may not exist yet (e.g. future GitHub Pages)
+  include `<!-- lychee skip -->` so lychee doesn’t report them.
+- When moving documentation files, verify relative paths so links keep working.
 - **Code changes** run full lint + tests (`test` & `test-win`) and `actionlint`.
 - Add job matrices or deployments later—guardrails above already catch the 90 %
   most common issues.

--- a/NOTES.md
+++ b/NOTES.md
@@ -1771,3 +1771,12 @@ TODO logs the task.
 - **Stage**: documentation
 - **Motivation / Decision**: show published docs and provide Sphinx overview.
 - **Next step**: none.
+
+### 2025-07-21  PR #???
+
+- **Summary**: AGENTS guide advises using `<!-- lychee skip -->` for future links
+  and checking relative paths after moving docs.
+- **Stage**: documentation
+- **Motivation / Decision**: avoid false link errors and ensure references stay
+  valid.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -204,3 +204,5 @@
 - [x] Ensure `test_pymake_works_from_subdirectory` stubs shutil.which for
       deterministic behavior.
 - [x] Reduce frame capture interval in PoseViewer to 25ms for smoother video.
+- [x] Document lychee skip for future links and verify relative paths when
+      moving docs.


### PR DESCRIPTION
## Summary
- document skipping future links for lychee
- advise checking relative paths when moving docs
- note new rule in project history

## Testing
- `make lint-docs`
- `lychee --no-progress --verbose '**/*.md'`

------
https://chatgpt.com/codex/tasks/task_e_687e3e5814d48325a8b0a7956f36940e