### PR TITLE
Filter out low visibility landmarks

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1779,7 +1779,15 @@ TODO logs the task.
 - **Motivation / Decision**: markdown-link-check expected path from source dir.
 
 ### 2025-07-21  PR #231
+
 - **Summary**: added lychee skip comment after Pages deployment link.
 - **Stage**: documentation
 - **Motivation / Decision**: ensure link checker passes for remote URL.
+- **Next step**: none.
+
+### 2025-07-21  PR #232
+
+- **Summary**: filtered low-visibility landmarks in PoseDetector and added test.
+- **Stage**: implementation
+- **Motivation / Decision**: discard unreliable points using VISIBILITY_MIN.
 - **Next step**: none.

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+"""Backend configuration constants."""
+
+VISIBILITY_MIN = 0.5

--- a/backend/pose/__init__.py
+++ b/backend/pose/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/backend/pose/landmark_utils.py
+++ b/backend/pose/landmark_utils.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+def filter_visible(
+    keypoints: List[Dict[str, float]], threshold: float
+) -> List[Dict[str, float]]:
+    """Return points with visibility >= threshold."""
+    return [pt for pt in keypoints if pt.get("visibility", 0.0) >= threshold]

--- a/backend/pose_detector.py
+++ b/backend/pose_detector.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
 import cv2
 import mediapipe as mp
 import numpy as np
+
+from .config import VISIBILITY_MIN
+from .pose.landmark_utils import filter_visible
 
 
 class PoseDetector:
@@ -54,7 +59,7 @@ class PoseDetector:
                     "visibility": float(lm.visibility),
                 }
             )
-        return keypoints
+        return filter_visible(keypoints, VISIBILITY_MIN)
 
     def close(self) -> None:
         """Release MediaPipe resources."""

--- a/tests/backend/test_pose_detector.py
+++ b/tests/backend/test_pose_detector.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import types
 import numpy as np
 import backend.pose_detector as pd
+from backend.config import VISIBILITY_MIN
 import mediapipe as mp
 
 
@@ -110,3 +113,24 @@ def test_init_uses_model_complexity_constant(monkeypatch):
     assert (
         InspectPose.kwargs.get("model_complexity") == pd.PoseDetector.MODEL_COMPLEXITY
     )
+
+
+def test_visibility_filter(monkeypatch):
+    class LowVisPose:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def process(self, _frame):
+            lm = types.SimpleNamespace(x=0.0, y=0.0, visibility=VISIBILITY_MIN - 0.1)
+            return types.SimpleNamespace(
+                pose_landmarks=types.SimpleNamespace(landmark=[lm] * 33)
+            )
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(mp.solutions.pose, "Pose", LowVisPose)
+    det = pd.PoseDetector()
+    frame = np.zeros((1, 1, 3), dtype=np.uint8)
+    result = det.process(frame)
+    assert result == []


### PR DESCRIPTION
## Summary
- discard keypoints with low visibility using `filter_visible`
- expose threshold constant `VISIBILITY_MIN`
- test PoseDetector visibility filtering
- add missing `from __future__ import annotations` lines
- log new change in NOTES

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687e408185808325bfc529162ced34fa