### PR TITLE
Add config constant

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1779,7 +1779,15 @@ TODO logs the task.
 - **Motivation / Decision**: markdown-link-check expected path from source dir.
 
 ### 2025-07-21  PR #231
+
 - **Summary**: added lychee skip comment after Pages deployment link.
 - **Stage**: documentation
 - **Motivation / Decision**: ensure link checker passes for remote URL.
+- **Next step**: none.
+
+### 2025-07-21  PR #232
+
+- **Summary**: added backend config module with VISIBILITY_MIN constant and test.
+- **Stage**: implementation
+- **Motivation / Decision**: centralise landmark visibility threshold for reuse.
 - **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -204,3 +204,4 @@
 - [x] Ensure `test_pymake_works_from_subdirectory` stubs shutil.which for
       deterministic behavior.
 - [x] Reduce frame capture interval in PoseViewer to 25ms for smoother video.
+- [x] Centralise pose visibility threshold in backend config module.

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+"""Central configuration constants."""
+
+VISIBILITY_MIN = 0.50
+"""Minimum visibility score for pose landmarks."""

--- a/tests/backend/test_config.py
+++ b/tests/backend/test_config.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from backend import config
+
+
+def test_visibility_min_constant() -> None:
+    assert config.VISIBILITY_MIN == 0.50


### PR DESCRIPTION
## Summary
- centralize configuration constants in `backend/config.py`
- test visibility minimum constant
- log the change in NOTES and keep TODO up to date

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687e407e60bc8325ad27198b521c49fd