### PR TITLE
Skip low‑visibility pose landmarks

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1830,3 +1830,10 @@ TODO logs the task.
 - **Stage**: implementation
 - **Motivation / Decision**: maintain correct mapping when some landmarks are hidden.
 - **Next step**: none.
+
+### 2025-07-23  PR #239
+
+- **Summary**: skip low-confidence points via visibility; update types.
+- **Stage**: implementation
+- **Motivation / Decision**: draw code uses visibility filtering to cut noise.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -210,3 +210,5 @@
       moving docs.
 - [x] Add tests for filter_visible with out-of-range threshold raising ValueError.
 - [x] Preserve landmark names when filtering low visibility points.
+
+- [x] Skip drawing skeleton when visibility low; update PoseLandmark type.

--- a/frontend/src/__tests__/poseDrawing.test.tsx
+++ b/frontend/src/__tests__/poseDrawing.test.tsx
@@ -1,4 +1,4 @@
-import { drawSkeleton, EDGES, Point } from '../utils/poseDrawing';
+import { drawSkeleton, EDGES, PoseLandmark } from '../utils/poseDrawing';
 
 const makeCtx = () => {
   return {
@@ -19,9 +19,10 @@ const makeCtx = () => {
 
 test('drawSkeleton connects edge landmarks', () => {
   const ctx = makeCtx();
-  const landmarks: Point[] = Array.from({ length: 17 }, (_, i) => ({
+  const landmarks: PoseLandmark[] = Array.from({ length: 17 }, (_, i) => ({
     x: i / 100,
     y: i / 100,
+    visibility: 1,
   }));
   drawSkeleton(ctx, landmarks, 100, 100);
   expect(ctx.lineTo).toHaveBeenCalledTimes(EDGES.length);
@@ -70,6 +71,17 @@ test('lineWidth remains positive when context is mirrored', () => {
     transform = { a: transform.a * x };
   };
   (ctx as any).scale(-1, 1);
-  drawSkeleton(ctx, [{ x: 0, y: 0 }], 100, 100);
+  drawSkeleton(ctx, [{ x: 0, y: 0, visibility: 1 }], 100, 100);
   expect(ctx.lineWidth).toBeGreaterThan(0);
+});
+
+test('landmarks below visibility threshold are skipped', () => {
+  const ctx = makeCtx();
+  const landmarks: PoseLandmark[] = [
+    { x: 0, y: 0, visibility: 0.4 },
+    { x: 1, y: 1, visibility: 0.4 },
+  ];
+  drawSkeleton(ctx, landmarks, 100, 100, 0.5);
+  expect(ctx.moveTo).not.toHaveBeenCalled();
+  expect(ctx.arc).not.toHaveBeenCalled();
 });

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 import useWebSocket from '../hooks/useWebSocket';
-import { drawSkeleton, Point } from '../utils/poseDrawing';
+import { drawSkeleton, PoseLandmark } from '../utils/poseDrawing';
 import alignCanvasToVideo from '../utils/alignCanvas';
 import MetricsPanel, { PoseMetrics } from './MetricsPanel';
 
 interface PoseData {
-  landmarks: Point[];
+  landmarks: PoseLandmark[];
   metrics: PoseMetrics;
   model: string;
 }

--- a/frontend/src/utils/poseDrawing.ts
+++ b/frontend/src/utils/poseDrawing.ts
@@ -1,6 +1,7 @@
-export interface Point {
+export interface PoseLandmark {
   x: number;
   y: number;
+  visibility: number;
 }
 
 /**
@@ -31,9 +32,10 @@ export const EDGES: [number, number][] = [
  */
 export function drawSkeleton(
   ctx: CanvasRenderingContext2D,
-  landmarks: Point[],
+  landmarks: PoseLandmark[],
   videoWidth: number,
   videoHeight: number,
+  visibilityMin = 0.5,
 ): void {
   const scale = typeof (ctx as any).getTransform === 'function'
     ? Math.abs((ctx as any).getTransform().a) || 1
@@ -44,6 +46,7 @@ export function drawSkeleton(
     const pa = landmarks[a];
     const pb = landmarks[b];
     if (!pa || !pb) continue;
+    if (pa.visibility < visibilityMin || pb.visibility < visibilityMin) continue;
     ctx.beginPath();
     ctx.moveTo(pa.x * videoWidth, pa.y * videoHeight);
     ctx.lineTo(pb.x * videoWidth, pb.y * videoHeight);
@@ -52,6 +55,7 @@ export function drawSkeleton(
   ctx.fillStyle = 'red';
   const radius = 4 / scale;
   for (const p of landmarks) {
+    if (p.visibility < visibilityMin) continue;
     ctx.beginPath();
     ctx.arc(p.x * videoWidth, p.y * videoHeight, radius, 0, Math.PI * 2);
     ctx.fill();


### PR DESCRIPTION
## Summary
- use `PoseLandmark` instead of `Point`
- drawSkeleton skips edges and points under a visibility threshold
- update PoseViewer to pass new landmark type
- adapt tests for new visibility check
- track change in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`
- `make lint-docs`

------
https://chatgpt.com/codex/tasks/task_e_6880a09956fc8325837310a089ec5c8d