### PR TITLE
Update jest roots and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.52 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.53 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -142,6 +142,8 @@ prevents GitHub prompts.
     - `make test` expects dependencies from `.codex/setup.sh`.
     - Performance tests reside in `tests/performance` and run as part of
       `make test`. Execute them alone with `pytest tests/performance`.
+    - Frontend Jest tests may live in `frontend/src` or `tests/frontend`.
+      `make test` runs `npx jest` when any `*.test.tsx` file exists.
 3. **Style rules** – keep code formatted (`black`, `prettier`,
    `dart format`, etc.) and Markdown lines ≤ 80 chars;
    avoid multiple consecutive blank lines (markdownlint MD012);

--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,13 @@ lint-docs:
 
 test:
 	@if [ -d tests ]; then \
-	python -m pytest --cov=backend --cov=frontend --cov-config=.coveragerc --cov-fail-under=80; \
-	else \
-	echo "No tests yet"; \
-	fi
-	@if [ -d frontend/src/__tests__ ]; then \
-	npx --yes jest; \
-	fi
+		python -m pytest --cov=backend --cov=frontend --cov-config=.coveragerc --cov-fail-under=80; \
+		else \
+		echo "No tests yet"; \
+		fi
+	@if find frontend/src tests/frontend -name '*.test.tsx' -print -quit 2>/dev/null | grep -q .; then \
+		npx --yes jest; \
+		fi
 
 
 generate:

--- a/NOTES.md
+++ b/NOTES.md
@@ -1830,3 +1830,10 @@ TODO logs the task.
 - **Stage**: implementation
 - **Motivation / Decision**: maintain correct mapping when some landmarks are hidden.
 - **Next step**: none.
+
+### 2025-07-23  PR #239
+
+- **Summary**: jest config checks tests/frontend; Makefile auto-runs jest.
+- **Stage**: implementation
+- **Motivation / Decision**: unify test paths so CI finds them.
+- **Next step**: none.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,9 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
-  roots: ['<rootDir>/frontend/src'],
+  roots: ['<rootDir>/frontend/src', '<rootDir>/tests/frontend'],
   moduleFileExtensions: ['ts', 'tsx', 'js'],
-  testMatch: ['**/__tests__/**/*.test.tsx'],
+  testMatch: ['**/*.test.tsx'],
   transform: {
     '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'frontend/tsconfig.json' }]
   },

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -8,7 +8,8 @@ if (Test-Path 'tests') {
 } else {
     Write-Host 'No tests yet'
 }
-if (Test-Path 'frontend/src/__tests__') {
+$hasFrontendTests = Get-ChildItem 'frontend/src','tests/frontend' -Recurse -Filter '*.test.tsx' -ErrorAction SilentlyContinue | Select-Object -First 1
+if ($hasFrontendTests) {
     npx --yes jest
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 }


### PR DESCRIPTION
## Summary
- support `tests/frontend` in Jest config
- run Jest when any frontend tests exist
- document new test location in AGENTS guide

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`
- `make lint-docs`


------
https://chatgpt.com/codex/tasks/task_e_6880a0a7a79c83258bb77553e54b5bb2