### PR TITLE
Add visibility-aware skeleton drawing test

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1830,3 +1830,11 @@ TODO logs the task.
 - **Stage**: implementation
 - **Motivation / Decision**: maintain correct mapping when some landmarks are hidden.
 - **Next step**: none.
+
+### 2025-07-23  PR #\<number>
+
+- **Summary**: skip drawing hidden landmarks below visibility threshold.
+- **Summary**: jest config now searches tests/frontend.
+- **Stage**: implementation
+- **Motivation / Decision**: front-end now skips hidden points; new tests root.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -210,3 +210,4 @@
       moving docs.
 - [x] Add tests for filter_visible with out-of-range threshold raising ValueError.
 - [x] Preserve landmark names when filtering low visibility points.
+- [x] Skip drawing landmarks with visibility below threshold in frontend.

--- a/frontend/src/utils/poseDrawing.ts
+++ b/frontend/src/utils/poseDrawing.ts
@@ -1,7 +1,10 @@
 export interface Point {
   x: number;
   y: number;
+  visibility?: number;
 }
+
+const VISIBILITY_MIN = 0.5;
 
 /**
  * Index pairs describing how to connect the pose landmarks.
@@ -44,6 +47,8 @@ export function drawSkeleton(
     const pa = landmarks[a];
     const pb = landmarks[b];
     if (!pa || !pb) continue;
+    if ((pa.visibility ?? 1) < VISIBILITY_MIN) continue;
+    if ((pb.visibility ?? 1) < VISIBILITY_MIN) continue;
     ctx.beginPath();
     ctx.moveTo(pa.x * videoWidth, pa.y * videoHeight);
     ctx.lineTo(pb.x * videoWidth, pb.y * videoHeight);
@@ -52,6 +57,9 @@ export function drawSkeleton(
   ctx.fillStyle = 'red';
   const radius = 4 / scale;
   for (const p of landmarks) {
+    if ((p.visibility ?? 1) < VISIBILITY_MIN) {
+      continue;
+    }
     ctx.beginPath();
     ctx.arc(p.x * videoWidth, p.y * videoHeight, radius, 0, Math.PI * 2);
     ctx.fill();

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -9,5 +9,5 @@
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "../tests/frontend/**/*"]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,9 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
-  roots: ['<rootDir>/frontend/src'],
+  roots: ['<rootDir>/frontend/src', '<rootDir>/tests/frontend'],
   moduleFileExtensions: ['ts', 'tsx', 'js'],
-  testMatch: ['**/__tests__/**/*.test.tsx'],
+  testMatch: ['**/*.test.tsx'],
   transform: {
     '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'frontend/tsconfig.json' }]
   },

--- a/tests/frontend/poseDrawing.test.tsx
+++ b/tests/frontend/poseDrawing.test.tsx
@@ -1,0 +1,39 @@
+import { drawSkeleton, EDGES, Point } from '../../frontend/src/utils/poseDrawing';
+
+const makeCtx = () => {
+  return {
+    canvas: { width: 100, height: 100 },
+    clearRect: jest.fn(),
+    beginPath: jest.fn(),
+    moveTo: jest.fn(),
+    lineTo: jest.fn(),
+    stroke: jest.fn(),
+    arc: jest.fn(),
+    fill: jest.fn(),
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 0,
+    getTransform: () => ({ a: 1 }),
+  } as unknown as CanvasRenderingContext2D;
+};
+
+test('low visibility landmarks are skipped', () => {
+  const ctx = makeCtx();
+  const landmarks: Point[] = Array.from({ length: 17 }, (_, i) => ({
+    x: i / 10,
+    y: i / 10,
+    visibility: i % 2 ? 0.4 : 0.9,
+  }));
+
+  const expectedEdges = EDGES.filter(([a, b]) =>
+    (landmarks[a].visibility ?? 1) >= 0.5 &&
+    (landmarks[b].visibility ?? 1) >= 0.5,
+  );
+
+  drawSkeleton(ctx, landmarks, 100, 100);
+
+  expect((ctx.arc as jest.Mock).mock.calls.length).toBe(
+    landmarks.filter(p => (p.visibility ?? 1) >= 0.5).length,
+  );
+  expect((ctx.lineTo as jest.Mock).mock.calls.length).toBe(expectedEdges.length);
+});


### PR DESCRIPTION
## Summary
- skip low-visibility landmarks in `drawSkeleton`
- teach jest about `tests/frontend`
- compile frontend tests via updated tsconfig
- cover new behaviour with a dedicated test
- document the change in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6880a0abfb588325bcca85d3c203567a