### PR TITLE
Fix Windows job setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,11 +98,19 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
       - name: Bootstrap
         run: ./scripts/setup.ps1
         shell: pwsh
         env:
           SKIP_PRECOMMIT: '1'
+          PYTHON_VERSION: '3.11'
+          NODE_VERSION: '20'
       - run: scripts\lint.ps1
         shell: pwsh
       - run: python pymake.py lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,11 +266,19 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
       - name: Bootstrap
         run: ./scripts/setup.ps1
         shell: pwsh
         env:
           SKIP_PRECOMMIT: '1'
+          PYTHON_VERSION: '3.11'
+          NODE_VERSION: '20'
       - run: scripts\lint.ps1
         shell: pwsh
       - run: python pymake.py lint

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 lint:
 	npx --yes markdownlint-cli '**/*.md' --ignore node_modules --ignore .pre-commit-cache --ignore frontend/dist --ignore docs/_build
-	black --check backend scripts tests docs pymake.py
+	python -m black --check backend scripts tests docs pymake.py
 	ruff check backend scripts tests pymake.py
 	python scripts/repo_checks.py
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1910,3 +1910,12 @@ TODO logs the task.
 - **Motivation / Decision**: keep overlay scaling stable and simplify context
   transforms.
 - **Next step**: none.
+
+### 2025-07-24  PR #250
+
+- **Summary**: Windows CI installs Python 3.11 and Node 20 before setup and
+  linting uses `python -m black` to avoid PATH issues.
+- **Stage**: implementation
+- **Motivation / Decision**: ensure consistent tool versions and reliable
+  invocation on Windows runners.
+- **Next step**: none.

--- a/scripts/lint.ps1
+++ b/scripts/lint.ps1
@@ -4,7 +4,7 @@ Set-Location (Join-Path $scriptDir '..')
 
 npx --yes markdownlint-cli '**/*.md' --ignore node_modules --ignore .pre-commit-cache --ignore frontend/dist --ignore docs/_build
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-black --check backend scripts tests docs
+python -m black --check backend scripts tests docs
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 ruff check backend scripts tests
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/tests/frontend/poseDrawingCanvas.test.tsx
+++ b/tests/frontend/poseDrawingCanvas.test.tsx
@@ -19,7 +19,8 @@ test('drawSkeleton only connects visible landmarks within bounds', () => {
   landmarks[6] = { x: 0.2, y: 0.6, visibility: 0.4 };
   landmarks[8] = { x: 0.8, y: 0.6, visibility: 0.4 };
 
-  drawSkeleton(ctx, landmarks, 100, 50, 0.5);
+  const getScale = () => ({ scaleX: canvas.width, scaleY: canvas.height });
+  drawSkeleton(ctx, landmarks, getScale, 0.5);
 
   expect((ctx.lineTo as jest.Mock).mock.calls).toHaveLength(1);
 


### PR DESCRIPTION
## Summary
- install Python and Node on Windows CI job
- pass the versions through the environment
- call Black via `python -m` on Windows and in Makefile
- document the new Windows steps
- update test for current drawSkeleton API

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`
- `python -m pre_commit run --files .github/workflows/ci.yml AGENTS.md Makefile NOTES.md scripts/lint.ps1 tests/frontend/poseDrawingCanvas.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6880b6000fec83259402c291ce3ef831