### PR TITLE
Simplify pose drawing pipeline

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1925,3 +1925,13 @@ TODO logs the task.
 - **Stage**: testing
 - **Motivation / Decision**: align test with new getScale design.
 - **Next step**: none.
+
+### 2025-07-26
+
+- **Summary**: simplified drawSkeleton to use canvas size and removed the scale
+  callback. PoseViewer skips drawing when tab hidden and resizes only on events.
+  Updated tests accordingly.
+- **Stage**: implementation
+- **Motivation / Decision**: streamline overlay logic
+  and avoid unnecessary transforms.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -176,11 +176,11 @@ WebSocket connection. It calls `setStreaming(!streaming)` in
 draws lines between keypoints to show the pose skeleton. The helper
 `resizeCanvas` reads `video.getBoundingClientRect()` and
 multiplies the bounds by `window.devicePixelRatio`. It sets the canvas
-width and height so drawing uses video pixels and stores the scaling
-factors. `PoseViewer` listens for `loadedmetadata` on the video and the
-`resize` event on `window` to keep the overlay aligned. When drawing,
-PoseViewer saves the context, uses `getScale()` to scale from the video
-size and flips horizontally if the video is mirrored. The
+width and height so drawing uses video pixels. `PoseViewer` listens for
+`loadedmetadata` on the video and the `resize` event on `window` to keep the
+overlay aligned. When drawing, PoseViewer saves the context, flips horizontally
+if the video is mirrored and then calls `drawSkeleton(ctx, poseData.landmarks,
+0.5)`. The
 surrounding
 
 `.pose-container` is styled so the canvas and video stack on top of each other.

--- a/frontend/src/__tests__/PoseViewer.test.tsx
+++ b/frontend/src/__tests__/PoseViewer.test.tsx
@@ -180,8 +180,7 @@ test('mirrors context when video transform flips horizontally', async () => {
     expect(ctx.scale).toHaveBeenCalledWith(-1, 1);
     expect(mockDraw).toHaveBeenCalled();
     const call = mockDraw.mock.calls[0];
-    const scale = call[2]();
-    expect(scale).toEqual({ scaleX: 100, scaleY: 50 });
+    expect(call[2]).toBe(0.5);
   });
   spy.mockRestore();
   Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
@@ -248,7 +247,7 @@ test('scales context when rect size differs from video size', async () => {
     expect(canvas.width).toBe(200);
     expect(canvas.height).toBe(100);
     expect(ctx.save).toHaveBeenCalled();
-    expect(ctx.scale).toHaveBeenCalledWith(0.5, 0.5);
+    expect(ctx.scale).not.toHaveBeenCalled();
   });
   Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
     configurable: true,
@@ -378,7 +377,7 @@ test('sends frames over WebSocket', async () => {
     await Promise.resolve();
   });
   expect(ctx.save).toHaveBeenCalled();
-  expect(ctx.scale).toHaveBeenCalledWith(2, 2);
+  expect(ctx.scale).not.toHaveBeenCalled();
   expect(canvas.width).toBe(2);
   expect(canvas.height).toBe(2);
   rect.width = 2;
@@ -393,7 +392,7 @@ test('sends frames over WebSocket', async () => {
   });
   expect(canvas.width).toBe(4);
   expect(canvas.height).toBe(4);
-  expect(ctx.scale).toHaveBeenLastCalledWith(4, 4);
+  expect(ctx.scale).not.toHaveBeenCalled();
   expect(send).toHaveBeenCalled();
   Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
     configurable: true,

--- a/frontend/src/__tests__/poseDrawing.test.tsx
+++ b/frontend/src/__tests__/poseDrawing.test.tsx
@@ -24,7 +24,7 @@ test('drawSkeleton connects edge landmarks', () => {
     y: i / 100,
     visibility: 1,
   }));
-  drawSkeleton(ctx, landmarks, () => ({ scaleX: 100, scaleY: 100 }));
+  drawSkeleton(ctx, landmarks);
   expect(ctx.lineTo).toHaveBeenCalledTimes(EDGES.length);
   EDGES.forEach((edge, i) => {
     const s = landmarks[edge[0]];
@@ -59,7 +59,7 @@ test('edges list matches 17-point skeleton', () => {
 test('drawSkeleton sets line width based on transform scale', () => {
   const ctx = makeCtx();
   ctx.getTransform = () => ({ a: 0.5 } as DOMMatrix);
-  drawSkeleton(ctx, [], () => ({ scaleX: 100, scaleY: 100 }));
+  drawSkeleton(ctx, []);
   expect(ctx.lineWidth).toBeCloseTo(4);
 });
 
@@ -71,7 +71,7 @@ test('lineWidth remains positive when context is mirrored', () => {
     transform = { a: transform.a * x };
   };
   (ctx as any).scale(-1, 1);
-  drawSkeleton(ctx, [{ x: 0, y: 0, visibility: 1 }], () => ({ scaleX: 100, scaleY: 100 }));
+  drawSkeleton(ctx, [{ x: 0, y: 0, visibility: 1 }]);
   expect(ctx.lineWidth).toBeGreaterThan(0);
 });
 
@@ -81,7 +81,7 @@ test('landmarks below visibility threshold are skipped', () => {
     { x: 0, y: 0, visibility: 0.4 },
     { x: 1, y: 1, visibility: 0.4 },
   ];
-  drawSkeleton(ctx, landmarks, () => ({ scaleX: 100, scaleY: 100 }), 0.5);
+  drawSkeleton(ctx, landmarks, 0.5);
   expect(ctx.moveTo).not.toHaveBeenCalled();
   expect(ctx.arc).not.toHaveBeenCalled();
 });

--- a/tests/frontend/poseDrawingCanvas.test.tsx
+++ b/tests/frontend/poseDrawingCanvas.test.tsx
@@ -1,5 +1,5 @@
 import 'jest-canvas-mock';
-import { drawSkeleton, PoseLandmark } from '../../frontend/src/utils/poseDrawing';
+import { drawSkeleton, PoseLandmark, EDGES } from '../../frontend/src/utils/poseDrawing';
 
 test('drawSkeleton only connects visible landmarks within bounds', () => {
   const canvas = document.createElement('canvas');
@@ -8,19 +8,18 @@ test('drawSkeleton only connects visible landmarks within bounds', () => {
   document.body.appendChild(canvas);
   const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
 
-  const landmarks: PoseLandmark[] = Array.from({ length: 17 }, () => ({
-    x: 0,
-    y: 0,
-    visibility: 0.4,
-  }));
+  const origEdges = [...EDGES];
+  (EDGES as [number, number][]).length = 0;
+  EDGES.push([0, 1]);
 
-  landmarks[5] = { x: 0.2, y: 0.3, visibility: 1 };
-  landmarks[7] = { x: 0.8, y: 0.3, visibility: 1 };
-  landmarks[6] = { x: 0.2, y: 0.6, visibility: 0.4 };
-  landmarks[8] = { x: 0.8, y: 0.6, visibility: 0.4 };
+  const landmarks: PoseLandmark[] = [
+    { x: 0.2, y: 0.3, visibility: 1 },
+    { x: 0.8, y: 0.3, visibility: 1 },
+    { x: 0.2, y: 0.6, visibility: 0.4 },
+    { x: 0.8, y: 0.6, visibility: 0.4 },
+  ];
 
-  const getScale = () => ({ scaleX: canvas.width, scaleY: canvas.height });
-  drawSkeleton(ctx, landmarks, getScale, 0.5);
+  drawSkeleton(ctx, landmarks, 0.5);
 
   expect((ctx.lineTo as jest.Mock).mock.calls).toHaveLength(1);
 
@@ -36,4 +35,7 @@ test('drawSkeleton only connects visible landmarks within bounds', () => {
   });
 
   expect((ctx.arc as jest.Mock).mock.calls).toHaveLength(2);
+
+  (EDGES as [number, number][]).length = 0;
+  origEdges.forEach((e) => EDGES.push(e));
 });


### PR DESCRIPTION
## Summary
- map landmarks to canvas size directly in `drawSkeleton`
- only draw edges when both endpoints are visible
- skip drawing while the document is hidden
- resize canvas only when metadata loads or the window resizes
- update tests for the new API

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6880bd5051c083258b9d6b0f9931b826