### PR TITLE
Update scripts for UTF-8 reading and annotations

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1941,3 +1941,10 @@ TODO logs the task.
 - **Stage**: documentation
 - **Motivation / Decision**: roadmap updated because setup script installs libgl1.
 - **Next step**: none.
+
+### 2025-07-23  PR #254
+
+- **Summary**: added future imports to scripts and forced UTF-8 for text IO.
+- **Stage**: implementation
+- **Motivation / Decision**: support Python 3.9 and avoid encoding issues.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -217,3 +217,4 @@
 - [x] Install minimal OpenCV runtime libs via setup script.
 - [x] Refactor drawSkeleton to accept a getScale callback and skip invisible landmarks.
 - [x] Update canvas test to call drawSkeleton with the getScale callback.
+- [x] Add future imports and UTF-8 encoding to helper scripts.

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import sys
 from pathlib import Path
@@ -11,7 +13,7 @@ NPM_URL = "https://registry.npmjs.org/{name}/{version}"
 def parse_requirements(req_path: Path) -> dict[str, str]:
     """Return package versions from requirements.txt."""
     packages: dict[str, str] = {}
-    for line in req_path.read_text().splitlines():
+    for line in req_path.read_text(encoding="utf-8").splitlines():
         line = line.strip()
         if not line or line.startswith("#"):
             continue
@@ -26,7 +28,7 @@ def parse_requirements(req_path: Path) -> dict[str, str]:
 
 def parse_package_json(json_path: Path) -> dict[str, str]:
     """Return dependencies from package.json."""
-    data = json.loads(json_path.read_text())
+    data = json.loads(json_path.read_text(encoding="utf-8"))
     packages: dict[str, str] = {}
     for section in ("dependencies", "devDependencies"):
         for name, version in data.get(section, {}).items():
@@ -36,7 +38,7 @@ def parse_package_json(json_path: Path) -> dict[str, str]:
 
 def parse_package_lock(lock_path: Path) -> dict[str, str]:
     """Return dependencies from package-lock.json."""
-    data = json.loads(lock_path.read_text())
+    data = json.loads(lock_path.read_text(encoding="utf-8"))
     root = data.get("packages", {}).get("", {})
     packages: dict[str, str] = {}
     for section in ("dependencies", "devDependencies"):

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 
@@ -26,7 +28,7 @@ def generate() -> int:
     try:
         out_path = Path(__file__).resolve().parents[1] / "generated" / "example.txt"
         out_path.parent.mkdir(parents=True, exist_ok=True)
-        out_path.write_text("placeholder output\n")
+        out_path.write_text("placeholder output\n", encoding="utf-8")
     except Exception as exc:  # defensive coding
         print(f"error: {exc}", file=sys.stderr)
         return 1


### PR DESCRIPTION
## Summary
- add missing future annotations in helper scripts
- enforce UTF-8 encoding on `read_text` and `write_text`
- record the update in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`
- `python -m pre_commit run --files NOTES.md TODO.md scripts/check_versions.py scripts/generate.py`

------
https://chatgpt.com/codex/tasks/task_e_6880c6a50cb883258e3108440b34c031