### PR TITLE
Fix cross-platform TODO updater

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1941,3 +1941,11 @@ TODO logs the task.
 - **Stage**: documentation
 - **Motivation / Decision**: roadmap updated because setup script installs libgl1.
 - **Next step**: none.
+
+### 2025-07-26  PR #254
+
+- **Summary**: updated update_todo_date script to use explicit UTF-8 encoding
+  and future import.
+- **Stage**: implementation
+- **Motivation / Decision**: ensure cross-platform TODO date updates.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -217,3 +217,4 @@
 - [x] Install minimal OpenCV runtime libs via setup script.
 - [x] Refactor drawSkeleton to accept a getScale callback and skip invisible landmarks.
 - [x] Update canvas test to call drawSkeleton with the getScale callback.
+- [x] Make the TODO date updater cross-platform.

--- a/scripts/update_todo_date.py
+++ b/scripts/update_todo_date.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 import sys
 from datetime import date
@@ -29,7 +31,7 @@ def update_todo_date(todo_path: Path) -> int:
         issues are caught and converted into the return code.
     """
     try:
-        lines = todo_path.read_text().splitlines()
+        lines = todo_path.read_text(encoding="utf-8").splitlines()
     except Exception as exc:  # defensive coding
         print(f"error: {exc}", file=sys.stderr)
         return 1
@@ -47,7 +49,7 @@ def update_todo_date(todo_path: Path) -> int:
         return 0
     lines[0] = f"{match.group(1)}{today}{match.group(3)}"
     try:
-        todo_path.write_text("\n".join(lines) + "\n")
+        todo_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     except Exception as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1

--- a/tests/test_update_todo_date.py
+++ b/tests/test_update_todo_date.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from datetime import date
 from pathlib import Path
@@ -7,7 +9,7 @@ import subprocess
 def test_update_todo_date(tmp_path):
     sample = "# TODO – Road‑map (last updated: 2000-01-01)\n" "\n" "rest\n"
     todo_file = tmp_path / "TODO.md"
-    todo_file.write_text(sample)
+    todo_file.write_text(sample, encoding="utf-8")
 
     repo_root = Path(__file__).resolve().parents[1]
     script = repo_root / "scripts" / "update_todo_date.py"
@@ -22,7 +24,7 @@ def test_update_todo_date(tmp_path):
 def test_update_todo_date_bad_header(tmp_path):
     sample = "# TODO wrong header\nrest\n"
     todo_file = tmp_path / "TODO.md"
-    todo_file.write_text(sample)
+    todo_file.write_text(sample, encoding="utf-8")
 
     repo_root = Path(__file__).resolve().parents[1]
     script = repo_root / "scripts" / "update_todo_date.py"


### PR DESCRIPTION
## Summary
- handle UTF-8 encoding for TODO updater script
- update its tests
- log new change
- mark roadmap item done

## Testing
- `.codex/setup.sh`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6880c6a490d88325a02131ee0e0bfbbd