### PR TITLE
Update AGENTS guide for encoding rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.54 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.55 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -329,6 +329,8 @@ jobs:
   they run deterministically across CI runners.
 - Use the same clock source for all duration measurements; in browsers call
   `performance.now()`.
+- Always pass `encoding="utf-8"` to `open` when reading or
+  writing text files to avoid locale issues.
 
 ---
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1941,3 +1941,10 @@ TODO logs the task.
 - **Stage**: documentation
 - **Motivation / Decision**: roadmap updated because setup script installs libgl1.
 - **Next step**: none.
+
+### 2025-07-23  PR #254
+
+- **Summary**: bumped AGENTS guide to v1.55 and noted UTF-8 encoding for files.
+- **Stage**: documentation
+- **Motivation / Decision**: prevent locale errors when reading or writing files.
+- **Next step**: none.


### PR DESCRIPTION
## Summary
- bump AGENTS guide to v1.55
- document using UTF-8 encoding for text file reads/writes
- log the update in NOTES

## Testing
- `make lint-docs`
- `python3 -m pre_commit run --files AGENTS.md NOTES.md`
- `lychee --no-progress '**/*.md'` *(failed: many unreachable links)*

------
https://chatgpt.com/codex/tasks/task_e_6880c6a6178483258478742a89ad2bd9