### PR TITLE
Fix resizeCanvas duplicates

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1960,4 +1960,12 @@ TODO logs the task.
 - **Summary**: added future imports to scripts and forced UTF-8 for text IO.
 - **Stage**: implementation
 - **Motivation / Decision**: support Python 3.9 and avoid encoding issues.
+
+- **Next step**: none.
+
+### 2025-07-23
+
+- **Summary**: made resizeCanvas idempotent, updated docs and added a Jest test.
+- **Stage**: implementation
+- **Motivation / Decision**: prevent unnecessary canvas updates causing flicker.
 - **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ WebSocket connection. It calls `setStreaming(!streaming)` in
 draws lines between keypoints to show the pose skeleton. The helper
 `resizeCanvas` reads `video.getBoundingClientRect()` and
 multiplies the bounds by `window.devicePixelRatio`. It sets the canvas
-width and height so drawing uses video pixels. `PoseViewer` listens for
+width and height so drawing uses video pixels and only updates these
+properties when the new values differ. `PoseViewer` listens for
 `loadedmetadata` on the video and the `resize` event on `window` to keep the
 overlay aligned. When drawing, PoseViewer saves the context, flips horizontally
 if the video is mirrored and then calls `drawSkeleton(ctx, poseData.landmarks,

--- a/TODO.md
+++ b/TODO.md
@@ -219,3 +219,5 @@
 - [x] Update canvas test to call drawSkeleton with the getScale callback.
 - [x] Make the TODO date updater cross-platform.
 - [x] Add future imports and UTF-8 encoding to helper scripts.
+- [x] Avoid unnecessary canvas resizing; make `resizeCanvas` idempotent
+  and add a unit test.

--- a/frontend/src/utils/poseDrawing.ts
+++ b/frontend/src/utils/poseDrawing.ts
@@ -38,10 +38,16 @@ export const { resizeCanvas, getScale } = (() => {
   function resizeCanvas(video: HTMLVideoElement, canvas: HTMLCanvasElement): void {
     const rect = video.getBoundingClientRect();
     const dpr = window.devicePixelRatio || 1;
-    canvas.width = rect.width * dpr;
-    canvas.height = rect.height * dpr;
-    canvas.style.width = `${rect.width}px`;
-    canvas.style.height = `${rect.height}px`;
+    const nextW = rect.width * dpr;
+    const nextH = rect.height * dpr;
+    if (canvas.width !== nextW) {
+      canvas.width = nextW;
+      canvas.style.width = `${rect.width}px`;
+    }
+    if (canvas.height !== nextH) {
+      canvas.height = nextH;
+      canvas.style.height = `${rect.height}px`;
+    }
     if (video.videoWidth && video.videoHeight) {
       scaleX = canvas.width / video.videoWidth;
       scaleY = canvas.height / video.videoHeight;

--- a/tests/frontend/poseDrawingCanvas.test.tsx
+++ b/tests/frontend/poseDrawingCanvas.test.tsx
@@ -1,5 +1,5 @@
 import 'jest-canvas-mock';
-import { drawSkeleton, PoseLandmark, EDGES } from '../../frontend/src/utils/poseDrawing';
+import { drawSkeleton, resizeCanvas, PoseLandmark, EDGES } from '../../frontend/src/utils/poseDrawing';
 
 test('drawSkeleton only connects visible landmarks within bounds', () => {
   const canvas = document.createElement('canvas');
@@ -38,4 +38,28 @@ test('drawSkeleton only connects visible landmarks within bounds', () => {
 
   (EDGES as [number, number][]).length = 0;
   origEdges.forEach((e) => EDGES.push(e));
+});
+
+test('resizeCanvas is idempotent for identical sizes', () => {
+  const video = document.createElement('video');
+  Object.defineProperty(video, 'getBoundingClientRect', {
+    value: () => ({
+      width: 80,
+      height: 60,
+      top: 0,
+      left: 0,
+      right: 80,
+      bottom: 60,
+      x: 0,
+      y: 0,
+      toJSON: () => '{}',
+    }),
+  });
+  const canvas = document.createElement('canvas');
+  resizeCanvas(video, canvas);
+  const w = canvas.width;
+  const h = canvas.height;
+  resizeCanvas(video, canvas);
+  expect(canvas.width).toBe(w);
+  expect(canvas.height).toBe(h);
 });


### PR DESCRIPTION
## Summary
- avoid unnecessary canvas resizing
- test resizeCanvas idempotence
- document resizeCanvas only updating when needed
- record progress in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6880c9e49c8083259b149df18b8e21ef