### PR TITLE
Switch to FastAPI lifespan API

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1961,3 +1961,11 @@ TODO logs the task.
 - **Stage**: implementation
 - **Motivation / Decision**: support Python 3.9 and avoid encoding issues.
 - **Next step**: none.
+
+### 2025-07-24  PR #257
+
+- **Summary**: replaced FastAPI on_event hooks with lifespan context manager.
+- **Stage**: implementation
+- **Motivation / Decision**: align with FastAPI recommendation and avoid
+  deprecation warnings.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO – Road‑map (last updated: 2025-07-26)
+# TODO – Road‑map (last updated: 2025-07-23)
 
 > *Record only high‑level milestones here; break micro‑tasks out into Issues.*
 > **When you finish a task, tick it and append a short NOTE entry
@@ -219,3 +219,4 @@
 - [x] Update canvas test to call drawSkeleton with the getScale callback.
 - [x] Make the TODO date updater cross-platform.
 - [x] Add future imports and UTF-8 encoding to helper scripts.
+- [x] Replace FastAPI on_event decorators with lifespan context manager.


### PR DESCRIPTION
## Summary
- manage startup/shutdown with `lifespan` instead of deprecated `on_event`
- record the change in TODO and NOTES

## Testing
- `./.codex/setup.sh`
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6880c9f4b7788325a4572dd0aab0ed5f