### PR TITLE
Remove unused scale API

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1961,3 +1961,9 @@ TODO logs the task.
 - **Stage**: implementation
 - **Motivation / Decision**: support Python 3.9 and avoid encoding issues.
 - **Next step**: none.
+
+### 2025-07-23
+
+- **Summary**: removed getScale and scale variables, simplified resizeCanvas.
+- **Stage**: implementation
+- **Motivation / Decision**: cleanup as scale values unused.

--- a/frontend/src/utils/poseDrawing.ts
+++ b/frontend/src/utils/poseDrawing.ts
@@ -22,38 +22,19 @@ export const EDGES: [number, number][] = [
   [14, 16],
 ];
 
-interface Scale {
-  scaleX: number;
-  scaleY: number;
-}
-
 /**
- * Keep the canvas size in sync with the video element and cache the scaling
- * factors used when drawing. Call `getScale()` to retrieve the latest values.
+ * Keep the canvas size in sync with the video element.
+ * @param video Source video element.
+ * @param canvas Overlay canvas to resize.
  */
-export const { resizeCanvas, getScale } = (() => {
-  let scaleX = 1;
-  let scaleY = 1;
-
-  function resizeCanvas(video: HTMLVideoElement, canvas: HTMLCanvasElement): void {
-    const rect = video.getBoundingClientRect();
-    const dpr = window.devicePixelRatio || 1;
-    canvas.width = rect.width * dpr;
-    canvas.height = rect.height * dpr;
-    canvas.style.width = `${rect.width}px`;
-    canvas.style.height = `${rect.height}px`;
-    if (video.videoWidth && video.videoHeight) {
-      scaleX = canvas.width / video.videoWidth;
-      scaleY = canvas.height / video.videoHeight;
-    }
-  }
-
-  function getScale(): Scale {
-    return { scaleX, scaleY };
-  }
-
-  return { resizeCanvas, getScale };
-})();
+export function resizeCanvas(video: HTMLVideoElement, canvas: HTMLCanvasElement): void {
+  const rect = video.getBoundingClientRect();
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = rect.width * dpr;
+  canvas.height = rect.height * dpr;
+  canvas.style.width = `${rect.width}px`;
+  canvas.style.height = `${rect.height}px`;
+}
 
 /**
  * Draw pose landmarks and edges on a canvas.


### PR DESCRIPTION
## Summary
- simplify canvas resizing utility
- remove scale cache and `getScale`
- note cleanup in NOTES

## Testing
- `npm test`
- `make typecheck-ts`
- `make lint`
- `make typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6880c9de10bc832597920b3e8804f193