### PR TITLE
Implement sequential frame capture and median visibility

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1983,3 +1983,12 @@ TODO logs the task.
 - **Stage**: testing
 - **Motivation / Decision**: verify skeleton rendering is paused on hidden tabs.
 - **Next step**: none.
+
+### 2025-07-25  PR #260
+
+- **Summary**: refactored PoseViewer to capture frames on demand and use
+  median visibility for skeleton drawing. Added regression and delay tests.
+- **Stage**: implementation
+- **Motivation / Decision**: reduce dropped frames when backend is slow and
+  make visibility threshold adaptive.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -223,3 +223,5 @@
 - [x] Replace FastAPI on_event decorators with lifespan context manager.
 - [x] Avoid unnecessary canvas resizing; make `resizeCanvas` idempotent
   and add a unit test.
+- [ ] Capture frames on demand in PoseViewer; track dropped frames and
+      use a median visibility threshold.


### PR DESCRIPTION
## Summary
- capture frames in PoseViewer on demand instead of an interval
- track dropped frames and median landmark visibility
- adapt skeleton drawing threshold
- add regression and delay tests
- log new TODO item and note

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6880d63910748325b07e4da350d599b3