### PR TITLE
Improve PoseViewer readiness checks

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1992,3 +1992,12 @@ TODO logs the task.
 - **Motivation / Decision**: reduce dropped frames when backend is slow and
   make visibility threshold adaptive.
 - **Next step**: none.
+
+### 2025-07-23
+
+- **Summary**: improved PoseViewer with videoReady flag and watchdog capture.
+- Clamped threshold and reset encode state on disconnect.
+- **Stage**: implementation
+- **Motivation / Decision**: ensure frames capture only when video is ready
+  and avoid stalls when no pose data arrives.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -223,5 +223,5 @@
 - [x] Replace FastAPI on_event decorators with lifespan context manager.
 - [x] Avoid unnecessary canvas resizing; make `resizeCanvas` idempotent
   and add a unit test.
-- [ ] Capture frames on demand in PoseViewer; track dropped frames and
+- [x] Capture frames on demand in PoseViewer; track dropped frames and
       use a median visibility threshold.

--- a/frontend/src/__tests__/PoseViewer.test.tsx
+++ b/frontend/src/__tests__/PoseViewer.test.tsx
@@ -373,6 +373,7 @@ test('sends frames over WebSocket', async () => {
   });
   Object.defineProperty(video, 'videoWidth', { value: 1 });
   Object.defineProperty(video, 'videoHeight', { value: 1 });
+  Object.defineProperty(video, 'readyState', { value: 2 });
   fireEvent(video, new Event('loadedmetadata'));
   window.dispatchEvent(new Event('resize'));
   require('@testing-library/react').act(() => {
@@ -516,6 +517,7 @@ test('drops frames during backend delay', async () => {
   });
   Object.defineProperty(video, 'videoWidth', { value: 1 });
   Object.defineProperty(video, 'videoHeight', { value: 1 });
+  Object.defineProperty(video, 'readyState', { value: 2 });
   fireEvent(video, new Event('loadedmetadata'));
   window.dispatchEvent(new Event('resize'));
   await waitFor(() => expect(send).toHaveBeenCalledTimes(1));


### PR DESCRIPTION
## Summary
- add `videoReady` state for PoseViewer video element
- start capture only when video is ready
- reset encodePending when connection drops
- trigger capture watchdog every 500ms
- clamp skeleton visibility threshold
- update tests and docs

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6880ddeea2408325b2b9a1b08b86c60a