### PR TITLE
Docs clarify streaming and watchdog

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1992,3 +1992,13 @@ TODO logs the task.
 - **Motivation / Decision**: reduce dropped frames when backend is slow and
   make visibility threshold adaptive.
 - **Next step**: none.
+
+### 2025-07-23  PR #261
+
+- **Summary**: ticked the PoseViewer capture TODO and updated README to note
+  streaming starts after `canplay`, stops if the socket closes and uses a
+  500 ms watchdog to compute median visibility.
+- **Stage**: documentation
+- **Motivation / Decision**: keep docs aligned with the code and record task
+  completion.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -170,8 +170,9 @@ npm test
 ```
 
 The PoseViewer component shows the live webcam feed. The **Start Webcam**
-button toggles streaming on and off. Stopping the webcam also closes the
-WebSocket connection. It calls `setStreaming(!streaming)` in
+button toggles streaming on and off. Streaming begins once the webcam emits
+`canplay` so frames are only captured when the video can play. Closing the
+socket stops the loop. It calls `setStreaming(!streaming)` in
 [`PoseViewer.tsx`](frontend/src/components/PoseViewer.tsx). A canvas overlay
 draws lines between keypoints to show the pose skeleton. The helper
 `resizeCanvas` reads `video.getBoundingClientRect()` and
@@ -181,7 +182,8 @@ properties when the new values differ. `PoseViewer` listens for
 `loadedmetadata` on the video and the `resize` event on `window` to keep the
 overlay aligned. When drawing, PoseViewer saves the context, flips horizontally
 if the video is mirrored and then calls `drawSkeleton(ctx, poseData.landmarks,
-0.5)`. The
+threshold)`. The threshold is the median landmark visibility from the last
+500&nbsp;ms so skeleton drawing adapts when points are lost. The
 surrounding
 
 `.pose-container` is styled so the canvas and video stack on top of each other.

--- a/TODO.md
+++ b/TODO.md
@@ -223,5 +223,5 @@
 - [x] Replace FastAPI on_event decorators with lifespan context manager.
 - [x] Avoid unnecessary canvas resizing; make `resizeCanvas` idempotent
   and add a unit test.
-- [ ] Capture frames on demand in PoseViewer; track dropped frames and
+- [x] Capture frames on demand in PoseViewer; track dropped frames and
       use a median visibility threshold.


### PR DESCRIPTION
## Summary
- tick TODO for PoseViewer capture on demand
- mention 500 ms watchdog and capture behaviour in README
- log documentation update in NOTES

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6880ddf115108325b78b6b5ed15bac57