### PR TITLE
Update frontend capture rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide <!-- AGENTS.md v1.55 -->
+# Contributor & CI Guide <!-- AGENTS.md v1.56 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and CI
@@ -153,6 +153,8 @@ prevents GitHub prompts.
       `make test`. Execute them alone with `pytest tests/performance`.
     - Frontend Jest tests may live in `frontend/src` or `tests/frontend`.
       `make test` runs `npx jest` when any `*.test.tsx` file exists.
+    - Begin the frame loop only once the video fires `canplay` and the WebSocket
+      is open. Reset any `encodePending` flags when the socket errors.
 3. **Style rules** – keep code formatted (`black`, `prettier`,
    `dart format`, etc.) and Markdown lines ≤ 80 chars;
    avoid multiple consecutive blank lines (markdownlint MD012);

--- a/NOTES.md
+++ b/NOTES.md
@@ -1992,3 +1992,12 @@ TODO logs the task.
 - **Motivation / Decision**: reduce dropped frames when backend is slow and
   make visibility threshold adaptive.
 - **Next step**: none.
+
+### 2025-07-23  PR #261
+
+- **Summary**: added frontend guidance to start frame loop after `canplay` and
+  WebSocket open, and reset `encodePending` on socket errors.
+- **Stage**: documentation
+- **Motivation / Decision**: document safe capture start and recovery rules to
+  prevent hangs.
+- **Next step**: none.


### PR DESCRIPTION
## Summary
- add guidance to start capture loop only once webcam and WebSocket are ready
- document resetting of encodePending on socket errors
- bump AGENTS guide version
- log the update in NOTES

## Testing
- `make lint-docs`

------
https://chatgpt.com/codex/tasks/task_e_6880ddf522a0832595b0870cf8427b19