### PR TITLE
Add videoReady watchdog in PoseViewer

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1992,3 +1992,11 @@ TODO logs the task.
 - **Motivation / Decision**: reduce dropped frames when backend is slow and
   make visibility threshold adaptive.
 - **Next step**: none.
+
+### 2025-07-23  PR #???
+
+- **Summary**: added canplay handler and watchdog timer in PoseViewer with new tests.
+- **Stage**: implementation
+- **Motivation / Decision**: ensure first frame is captured once the video is
+  ready and resend frames when the backend is idle.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -223,5 +223,5 @@
 - [x] Replace FastAPI on_event decorators with lifespan context manager.
 - [x] Avoid unnecessary canvas resizing; make `resizeCanvas` idempotent
   and add a unit test.
-- [ ] Capture frames on demand in PoseViewer; track dropped frames and
+- [x] Capture frames on demand in PoseViewer; track dropped frames and
       use a median visibility threshold.


### PR DESCRIPTION
## Summary
- capture first frame after the `canplay` event
- schedule a watchdog to resend a frame when idle
- update PoseViewer tests for the new flow
- tick roadmap entry for capture-on-demand

## Testing
- `pre-commit run --files NOTES.md TODO.md frontend/src/__tests__/PoseViewer.test.tsx frontend/src/components/PoseViewer.tsx`
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6880ddefa7a883258f53640a6a39836e