### PR TITLE
Handle NaN metrics in WebSocket payloads

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -2018,3 +2018,11 @@ TODO logs the task.
 - **Motivation / Decision**: ensure frames capture only when video is ready
   and avoid stalls when no pose data arrives.
 - **Next step**: none.
+
+### 2025-07-24  PR #264
+
+- **Summary**: sanitized NaN metrics to null and updated tests/docs.
+- **Stage**: implementation
+- **Motivation / Decision**: ensure WebSocket payloads parse in browsers when
+landmarks are missing.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ balance, pose, knee angle, posture angle, FPS, infer and JSON times, encode
 time, blob size, draw time, uplink and wait times, downlink delay, latency,
 client FPS, dropped frames and the model name. When `psutil` is installed
 CPU and memory usage also appear.
+Metrics that cannot be computed (for example when landmarks are lost)
+are sent as `null` so the JSON payload never contains `NaN`.
 
 ## Running locally
 

--- a/TODO.md
+++ b/TODO.md
@@ -225,3 +225,4 @@
   and add a unit test.
 - [x] Capture frames on demand in PoseViewer; track dropped frames and
       use a median visibility threshold.
+- [x] Replace NaN metrics with null when serializing WebSocket payloads.

--- a/backend/analytics.py
+++ b/backend/analytics.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
-from math import atan2, degrees, sqrt
-from typing import Dict, Mapping
+from math import atan2, degrees, sqrt, isnan
+from typing import Dict, Mapping, Any
 
 
 Point = Mapping[str, float]
+
+
+def replace_nan(value: Any) -> Any:
+    """Return ``None`` if ``value`` is ``NaN``."""
+    return None if isinstance(value, float) and isnan(value) else value
 
 
 def _validate_point(pt: Mapping[str, float] | None) -> None:

--- a/backend/server.py
+++ b/backend/server.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Deque
 
 from .config import VISIBILITY_MIN
 
-from .analytics import extract_pose_metrics
+from .analytics import extract_pose_metrics, replace_nan
 from .pose_detector import PoseDetector
 
 try:
@@ -84,6 +84,7 @@ def build_payload(
     rss = int(sum(RSS_HISTORY) / len(RSS_HISTORY)) if RSS_HISTORY else 0
     metrics["cpu_percent"] = cpu
     metrics["rss_bytes"] = rss
+    metrics = {k: replace_nan(v) for k, v in metrics.items()}
     complexity = getattr(PoseDetector, "MODEL_COMPLEXITY", 1)
     model = "lite" if complexity == 0 else "full"
     return {"landmarks": points, "metrics": metrics, "model": model}
@@ -149,11 +150,11 @@ async def pose_endpoint(ws: WebSocket) -> None:
             json_ms = (time.perf_counter() - start_json) * 1000.0
             payload["metrics"].update(
                 {
-                    "infer_ms": infer_ms,
-                    "json_ms": json_ms,
-                    "uplink_ms": uplink_ms,
-                    "wait_ms": wait_ms,
-                    "ts_out": time.time(),
+                    "infer_ms": replace_nan(infer_ms),
+                    "json_ms": replace_nan(json_ms),
+                    "uplink_ms": replace_nan(uplink_ms),
+                    "wait_ms": replace_nan(wait_ms),
+                    "ts_out": replace_nan(time.time()),
                 }
             )
             try:

--- a/tests/backend/test_payload_json.py
+++ b/tests/backend/test_payload_json.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import json
+from backend.server import build_payload
+
+
+def test_build_payload_has_no_nan() -> None:
+    lms = [{"x": 0.0, "y": 0.0, "visibility": 0.0}] * 17
+    payload = build_payload(lms, 30.0, 30.0)
+    text = json.dumps(payload)
+    assert "NaN" not in text
+    data = json.loads(text)
+    assert data["metrics"]["knee_angle"] is None


### PR DESCRIPTION
## Summary
- add `replace_nan` helper to `analytics.py`
- use `replace_nan` in `build_payload` and WebSocket metrics
- ensure JSON metrics contain null instead of NaN
- test payload sanitization and integration path
- document sanitisation behaviour
- record changes in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6881f7fb0efc8325a4c603184a7cc718