### PR TITLE
Add frame dimension header

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -2035,3 +2035,12 @@ landmarks are missing.
 - **Motivation / Decision**: reduce bandwidth usage while maintaining image
   quality.
 - **Next step**: none.
+
+### 2025-07-24  PR #266
+
+- **Summary**: added width and height to WebSocket frame header and stored them
+  in the backend. Updated tests and capture logic.
+- **Stage**: implementation
+- **Motivation / Decision**: aid debugging and future features relying on
+  frame dimensions.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -226,4 +226,5 @@
 - [x] Capture frames on demand in PoseViewer; track dropped frames and
       use a median visibility threshold.
 - [x] Replace NaN metrics with null when serializing WebSocket payloads.
-- [ ] Scale captured frames before encoding and compress with JPEG quality 0.55.
+- [x] Scale captured frames before encoding and compress with JPEG quality 0.55.
+- [x] Prepend width and height to WebSocket frame header for debugging.

--- a/backend/server.py
+++ b/backend/server.py
@@ -49,6 +49,7 @@ PROC = psutil.Process() if psutil else None
 CPU_HISTORY: Deque[float] = deque(maxlen=5)
 RSS_HISTORY: Deque[int] = deque(maxlen=5)
 SAMPLER_TASK: asyncio.Task[None] | None = None
+LAST_FRAME_SIZE: Dict[str, int] = {"width": 0, "height": 0}
 
 # names for the 17-landmark subset used by PoseDetector
 _NAMES = [lm.name.lower() for lm in PoseDetector.LANDMARKS]
@@ -111,7 +112,10 @@ async def pose_endpoint(ws: WebSocket) -> None:
                 break
 
             ts_send = struct.unpack("<d", data[:8])[0]
-            frame_bytes = data[8:]
+            width, height = struct.unpack("<HH", data[8:12])
+            LAST_FRAME_SIZE["width"] = int(width)
+            LAST_FRAME_SIZE["height"] = int(height)
+            frame_bytes = data[12:]
             ts_recv_ms = time.time() * 1000.0
             ts_recv_perf = time.perf_counter()
             try:

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -65,8 +65,11 @@ const PoseViewer: React.FC = () => {
           setSizeKB(b.size / 1024);
           const ts = Date.now();
           tsSendRef.current = ts;
-          const buf = new ArrayBuffer(8 + b.size);
-          new DataView(buf).setFloat64(0, ts, true);
+          const buf = new ArrayBuffer(12 + b.size);
+          const view = new DataView(buf);
+          view.setFloat64(0, ts, true);
+          view.setUint16(8, off.width, true);
+          view.setUint16(10, off.height, true);
           let arrayBuf: ArrayBuffer;
           if ('arrayBuffer' in b) {
             arrayBuf = await (b as any).arrayBuffer();
@@ -77,7 +80,7 @@ const PoseViewer: React.FC = () => {
               fr.readAsArrayBuffer(b);
             });
           }
-          new Uint8Array(buf, 8).set(new Uint8Array(arrayBuf));
+          new Uint8Array(buf, 12).set(new Uint8Array(arrayBuf));
           send(buf);
         }
         encodePending.current = false;

--- a/tests/integration/test_webcam_device.py
+++ b/tests/integration/test_webcam_device.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import Any
 
 import numpy as np
+import struct
 
 import json
 import backend.server as server
@@ -47,7 +48,8 @@ def test_pose_endpoint_reads_frame(monkeypatch: Any) -> None:
     monkeypatch.setattr(server, "PoseDetector", lambda *_a, **_k: pose)
     frame = np.zeros((1, 1, 3), dtype=np.uint8)
     _, buf = server.cv2.imencode(".jpg", frame)
-    ws = DummyWS([buf.tobytes()])
+    header = struct.pack("<dHH", 0.0, 1, 1)
+    ws = DummyWS([header + buf.tobytes()])
     asyncio.run(server.pose_endpoint(ws))
 
     assert ws.sent
@@ -65,7 +67,8 @@ def test_pose_endpoint_sanitizes_missing_data(monkeypatch: Any) -> None:
     monkeypatch.setattr(server, "PoseDetector", lambda *_a, **_k: pose)
     frame = np.zeros((1, 1, 3), dtype=np.uint8)
     _, buf = server.cv2.imencode(".jpg", frame)
-    ws = DummyWS([buf.tobytes()])
+    header = struct.pack("<dHH", 0.0, 1, 1)
+    ws = DummyWS([header + buf.tobytes()])
     asyncio.run(server.pose_endpoint(ws))
 
     data = json.loads(ws.sent[0])

--- a/tests/performance/test_server_performance.py
+++ b/tests/performance/test_server_performance.py
@@ -3,6 +3,7 @@ import time
 from typing import Any
 import numpy as np
 import json
+import struct
 
 import backend.server as server
 
@@ -60,7 +61,8 @@ def test_pose_endpoint_performance(monkeypatch: Any) -> None:
 
     frame = np.zeros((1, 1, 3), dtype=np.uint8)
     _, buf = server.cv2.imencode(".jpg", frame)
-    frames = [buf.tobytes()] * frame_count
+    header = struct.pack("<dHH", 0.0, 1, 1)
+    frames = [header + buf.tobytes()] * frame_count
 
     ws = DummyWS(frames, recv_times, send_times)
     asyncio.run(server.pose_endpoint(ws))


### PR DESCRIPTION
## Summary
- prepend width and height to captured frame packets
- record frame dimensions in the backend
- update all tests for the new 12 byte header
- note work in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68871889866c8325b4bf97f072b29b55