### PR TITLE
Expose camera resolution metrics

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -2035,3 +2035,8 @@ landmarks are missing.
 - **Motivation / Decision**: reduce bandwidth usage while maintaining image
   quality.
 - **Next step**: none.
+\n### 2025-07-28  PR #???
+- **Summary**: added camera resolution hints and displayed active resolution.
+- **Stage**: implementation
+- **Motivation / Decision**: ensure consistent camera size and show settings in UI.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -226,4 +226,5 @@
 - [x] Capture frames on demand in PoseViewer; track dropped frames and
       use a median visibility threshold.
 - [x] Replace NaN metrics with null when serializing WebSocket payloads.
-- [ ] Scale captured frames before encoding and compress with JPEG quality 0.55.
+- [x] Scale captured frames before encoding and compress with JPEG quality 0.55.
+- [ ] Show camera input resolution in the Metrics panel.

--- a/frontend/src/__tests__/MetricsPanel.test.tsx
+++ b/frontend/src/__tests__/MetricsPanel.test.tsx
@@ -22,6 +22,8 @@ test('displays all metrics', () => {
         latencyMs: 9,
         clientFps: 15,
         droppedFrames: 2,
+        cameraWidth: 640,
+        cameraHeight: 360,
         model: 'lite',
         cpu_percent: 80,
         rss_bytes: 125829120,
@@ -44,6 +46,7 @@ test('displays all metrics', () => {
   expect(screen.getByText(/Latency: 9\.00 ms/)).toBeInTheDocument();
   expect(screen.getByText(/Client FPS: 15\.00/)).toBeInTheDocument();
   expect(screen.getByText(/Dropped Frames: 2/)).toBeInTheDocument();
+  expect(screen.getByText(/Camera input: 640×360/)).toBeInTheDocument();
   expect(screen.getByText(/Model: lite/)).toBeInTheDocument();
   expect(screen.getByText(/CPU: 80 %/)).toBeInTheDocument();
   expect(screen.getByText(/Mem: 120 MB/)).toBeInTheDocument();

--- a/frontend/src/__tests__/PoseViewer.test.tsx
+++ b/frontend/src/__tests__/PoseViewer.test.tsx
@@ -84,9 +84,22 @@ afterEach(() => {
   window.requestAnimationFrame = origRAF;
 });
 
+class FakeVideoTrack {
+  getSettings() {
+    return { width: 640, height: 360 };
+  }
+  stop() {
+    return undefined;
+  }
+}
+
 class FakeStream {
+  tracks = [new FakeVideoTrack()];
   getTracks() {
-    return [];
+    return this.tracks;
+  }
+  getVideoTracks() {
+    return this.tracks;
   }
 }
 
@@ -108,7 +121,9 @@ test('assigns webcam stream to video element', async () => {
     const video = container.querySelector('video') as HTMLVideoElement;
     expect(video.srcObject).toBe(stream);
   });
-  expect(getUserMedia).toHaveBeenCalled();
+  expect(getUserMedia).toHaveBeenCalledWith({
+    video: { width: { ideal: 640 }, height: { ideal: 360 } },
+  });
 });
 
 test('canvas matches video dimensions after metadata loads', async () => {
@@ -130,6 +145,8 @@ test('canvas matches video dimensions after metadata loads', async () => {
   await waitFor(() => {
     expect(canvas.width).toBe(640);
     expect(canvas.height).toBe(480);
+    const panel = container.querySelector('.metrics-panel');
+    expect(panel?.textContent).toContain('Camera input: 640×360');
   });
   HTMLVideoElement.prototype.getBoundingClientRect = origRect;
 });

--- a/frontend/src/components/MetricsPanel.tsx
+++ b/frontend/src/components/MetricsPanel.tsx
@@ -15,6 +15,8 @@ export interface PoseMetrics {
   latencyMs?: number;
   clientFps?: number;
   droppedFrames?: number;
+  cameraWidth?: number;
+  cameraHeight?: number;
   model?: string;
   cpu_percent?: number;
   rss_bytes?: number;
@@ -42,6 +44,8 @@ const MetricsPanel: React.FC<MetricsPanelProps> = ({ data }) => {
   const latencyMs = Number(data?.latencyMs ?? 0);
   const clientFps = Number(data?.clientFps ?? 0);
   const droppedFrames = Number(data?.droppedFrames ?? 0);
+  const camW = Number(data?.cameraWidth ?? 0);
+  const camH = Number(data?.cameraHeight ?? 0);
   const model = data?.model ?? '';
   const cpu = Number((data as any)?.cpu_percent ?? 0);
   const rssMB = Number((data as any)?.rss_bytes ?? 0) / (1024 * 1024);
@@ -63,6 +67,7 @@ const MetricsPanel: React.FC<MetricsPanelProps> = ({ data }) => {
       <p>Latency: {latencyMs.toFixed(2)} ms</p>
       <p>Client FPS: {clientFps.toFixed(2)}</p>
       <p>Dropped Frames: {droppedFrames}</p>
+      <p>Camera input: {camW}×{camH}</p>
       <p>Model: {model}</p>
       <p>CPU: {cpu.toFixed(0)} %</p>
       <p>Mem: {rssMB.toFixed(0)} MB</p>

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -29,6 +29,8 @@ const PoseViewer: React.FC = () => {
   const [drawMs, setDrawMs] = useState(0);
   const [downlinkMs, setDownlinkMs] = useState(0);
   const [latencyMs, setLatencyMs] = useState(0);
+  const [cameraWidth, setCameraWidth] = useState<number | null>(null);
+  const [cameraHeight, setCameraHeight] = useState<number | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const offscreenRef = useRef<HTMLCanvasElement>(document.createElement('canvas'));
   const encodePending = useRef(false);
@@ -145,7 +147,9 @@ const PoseViewer: React.FC = () => {
     if (streaming) {
       setCameraError(null);
       navigator.mediaDevices
-        .getUserMedia({ video: true })
+        .getUserMedia({
+          video: { width: { ideal: 640 }, height: { ideal: 360 } },
+        })
         .then((stream) => {
           if (cancel) {
             stream.getTracks().forEach((t) => t.stop());
@@ -153,6 +157,18 @@ const PoseViewer: React.FC = () => {
           }
           video.srcObject = stream;
           streamRef.current = stream;
+          const track = stream.getVideoTracks()[0];
+          const settings = track.getSettings();
+          console.log(
+            'Using camera resolution',
+            settings.width,
+            'x',
+            settings.height,
+          );
+          setCameraWidth(typeof settings.width === 'number' ? settings.width : null);
+          setCameraHeight(
+            typeof settings.height === 'number' ? settings.height : null,
+          );
         })
         .catch(() => {
           setCameraError('Webcam access denied');
@@ -162,6 +178,8 @@ const PoseViewer: React.FC = () => {
       streamRef.current = null;
       video.srcObject = null;
       setCameraError(null);
+      setCameraWidth(null);
+      setCameraHeight(null);
     }
     return () => {
       cancel = true;
@@ -171,6 +189,8 @@ const PoseViewer: React.FC = () => {
         streamRef.current = null;
       }
       setCameraError(null);
+      setCameraWidth(null);
+      setCameraHeight(null);
     };
   }, [streaming]);
 
@@ -235,7 +255,17 @@ const PoseViewer: React.FC = () => {
     requestAnimationFrame(captureAndSend);
   }, [poseData]);
 
-  const metrics: PoseMetrics | undefined = poseData
+  const baseMetrics: PoseMetrics = {
+    balance: 0,
+    pose_class: '',
+    knee_angle: 0,
+    posture_angle: 0,
+    fps: 0,
+    cameraWidth: cameraWidth ?? undefined,
+    cameraHeight: cameraHeight ?? undefined,
+  };
+
+  const metrics: PoseMetrics = poseData
     ? {
         ...poseData.metrics,
         fps: Number((poseData.metrics as any).fps ?? 0),
@@ -248,9 +278,11 @@ const PoseViewer: React.FC = () => {
         latencyMs,
         clientFps,
         droppedFrames,
+        cameraWidth: cameraWidth ?? undefined,
+        cameraHeight: cameraHeight ?? undefined,
         model: poseData.model,
       }
-    : undefined;
+    : baseMetrics;
 
   return (
     <>


### PR DESCRIPTION
## Summary
- hint for 640×360 resolution when requesting the webcam
- display camera resolution in the Metrics panel
- log actual track settings for ignored hints
- update related tests
- document work in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6887186c7a08832584734a52637bdc62