### PR TITLE
docs: mark frame scaling done

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -2035,3 +2035,10 @@ landmarks are missing.
 - **Motivation / Decision**: reduce bandwidth usage while maintaining image
   quality.
 - **Next step**: none.
+
+### 2025-07-28  PR #266
+
+- **Summary**: ticked frame scaling and compression item in TODO.
+- **Stage**: maintenance
+- **Motivation / Decision**: align checklist with implemented feature.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO – Road‑map (last updated: 2025-07-23)
+# TODO – Road‑map (last updated: 2025-07-28)
 
 > *Record only high‑level milestones here; break micro‑tasks out into Issues.*
 > **When you finish a task, tick it and append a short NOTE entry
@@ -226,4 +226,4 @@
 - [x] Capture frames on demand in PoseViewer; track dropped frames and
       use a median visibility threshold.
 - [x] Replace NaN metrics with null when serializing WebSocket payloads.
-- [ ] Scale captured frames before encoding and compress with JPEG quality 0.55.
+- [x] Scale captured frames before encoding and compress with JPEG quality 0.55.


### PR DESCRIPTION
## Summary
- mark frame scaling and compression task as done
- note the TODO alignment in NOTES

## Testing
- `make lint-docs`
- `python scripts/repo_checks.py`
- `make update-todo-date`

------
https://chatgpt.com/codex/tasks/task_e_6887186c001c832580de353524623f2b