### PR TITLE
Improve inference metrics

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -2035,3 +2035,12 @@ landmarks are missing.
 - **Motivation / Decision**: reduce bandwidth usage while maintaining image
   quality.
 - **Next step**: none.
+
+### 2025-07-28  PR #266
+
+- **Summary**: resized decoded frames before inference, timed pose.process
+  separately and exposed it as infer_ms. Added inference speed test and updated
+  existing tests.
+- **Stage**: implementation
+- **Motivation / Decision**: align metrics with performance spec.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO – Road‑map (last updated: 2025-07-23)
+# TODO – Road‑map (last updated: 2025-07-28)
 
 > *Record only high‑level milestones here; break micro‑tasks out into Issues.*
 > **When you finish a task, tick it and append a short NOTE entry
@@ -227,3 +227,5 @@
       use a median visibility threshold.
 - [x] Replace NaN metrics with null when serializing WebSocket payloads.
 - [ ] Scale captured frames before encoding and compress with JPEG quality 0.55.
+
+- [x] Resize decoded frames on the server to 256px and time pose inference separately.

--- a/tests/integration/test_webcam_device.py
+++ b/tests/integration/test_webcam_device.py
@@ -4,6 +4,7 @@ from typing import Any
 import numpy as np
 
 import json
+import struct
 import backend.server as server
 
 
@@ -47,7 +48,8 @@ def test_pose_endpoint_reads_frame(monkeypatch: Any) -> None:
     monkeypatch.setattr(server, "PoseDetector", lambda *_a, **_k: pose)
     frame = np.zeros((1, 1, 3), dtype=np.uint8)
     _, buf = server.cv2.imencode(".jpg", frame)
-    ws = DummyWS([buf.tobytes()])
+    data = struct.pack("<d", 0.0) + buf.tobytes()
+    ws = DummyWS([data])
     asyncio.run(server.pose_endpoint(ws))
 
     assert ws.sent
@@ -65,7 +67,8 @@ def test_pose_endpoint_sanitizes_missing_data(monkeypatch: Any) -> None:
     monkeypatch.setattr(server, "PoseDetector", lambda *_a, **_k: pose)
     frame = np.zeros((1, 1, 3), dtype=np.uint8)
     _, buf = server.cv2.imencode(".jpg", frame)
-    ws = DummyWS([buf.tobytes()])
+    data = struct.pack("<d", 0.0) + buf.tobytes()
+    ws = DummyWS([data])
     asyncio.run(server.pose_endpoint(ws))
 
     data = json.loads(ws.sent[0])

--- a/tests/performance/test_inference_speed.py
+++ b/tests/performance/test_inference_speed.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import time
+import numpy as np
+from backend.pose_detector import PoseDetector
+
+
+def test_inference_speed_under_40ms() -> None:
+    detector = PoseDetector()
+    frame = np.zeros((256, 256, 3), dtype=np.uint8)
+    durations = []
+    try:
+        detector.process(frame)  # warm-up
+        for _ in range(5):
+            start = time.perf_counter()
+            detector.process(frame)
+            durations.append((time.perf_counter() - start) * 1000.0)
+    finally:
+        detector.close()
+    avg = sum(durations) / len(durations)
+    assert avg < 40.0, f"average inference {avg:.2f} ms >= 40 ms"

--- a/tests/performance/test_server_performance.py
+++ b/tests/performance/test_server_performance.py
@@ -3,6 +3,7 @@ import time
 from typing import Any
 import numpy as np
 import json
+import struct
 
 import backend.server as server
 
@@ -46,8 +47,10 @@ class DummyWS:
         self.closed = True
 
 
-async def _dummy_process(det: DummyDetector, frame: Any) -> list[dict[str, float]]:
-    return det.process(frame)
+async def _dummy_process(
+    det: DummyDetector, frame: Any
+) -> tuple[list[dict[str, float]], float]:
+    return det.process(frame), 0.0
 
 
 def test_pose_endpoint_performance(monkeypatch: Any) -> None:
@@ -60,7 +63,8 @@ def test_pose_endpoint_performance(monkeypatch: Any) -> None:
 
     frame = np.zeros((1, 1, 3), dtype=np.uint8)
     _, buf = server.cv2.imencode(".jpg", frame)
-    frames = [buf.tobytes()] * frame_count
+    data = struct.pack("<d", 0.0) + buf.tobytes()
+    frames = [data] * frame_count
 
     ws = DummyWS(frames, recv_times, send_times)
     asyncio.run(server.pose_endpoint(ws))


### PR DESCRIPTION
## Summary
- resize decoded frames to 256px before inference
- time pose processing only and report as infer_ms
- adjust server tests to include timestamps and new timing
- add warm-up inference speed test
- document the change in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6887189c7f6883259eff4935962793b8