### PR TITLE
Align capture rate with inference time

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -2056,3 +2056,11 @@ landmarks are missing.
 - **Motivation / Decision**: aid debugging and future features relying on
   frame dimensions.
 - **Next step**: none.
+\n### 2025-07-28
+
+- **Summary**: delay frame capture using infer_ms and encodeMs. Added a
+  performance test.
+- **Stage**: implementation
+- **Motivation / Decision**: adapt capture rate to inference latency
+  to stabilize FPS.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -229,3 +229,4 @@
 - [x] Scale captured frames before encoding and compress with JPEG quality 0.55.
 - [ ] Show camera input resolution in the Metrics panel.
 - [x] Prepend width and height to WebSocket frame header for debugging.
+- [x] Delay next frame capture by infer_ms + encodeMs + 5 ms.

--- a/frontend/src/__tests__/PoseViewer.test.tsx
+++ b/frontend/src/__tests__/PoseViewer.test.tsx
@@ -1,11 +1,11 @@
-import { render, waitFor, fireEvent } from '@testing-library/react';
-import '@testing-library/jest-dom';
-import useWebSocket from '../hooks/useWebSocket';
-import { drawSkeleton } from '../utils/poseDrawing';
+import { render, waitFor, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import useWebSocket from "../hooks/useWebSocket";
+import { drawSkeleton } from "../utils/poseDrawing";
 
-jest.mock('../hooks/useWebSocket');
-jest.mock('../utils/poseDrawing', () => {
-  const actual = jest.requireActual('../utils/poseDrawing');
+jest.mock("../hooks/useWebSocket");
+jest.mock("../utils/poseDrawing", () => {
+  const actual = jest.requireActual("../utils/poseDrawing");
   return { ...actual, drawSkeleton: jest.fn() };
 });
 const mockWS = useWebSocket as jest.Mock;
@@ -15,21 +15,20 @@ let origDevicePixelRatio: number | undefined;
 let origRAF: typeof requestAnimationFrame;
 let mockToBlob: jest.Mock;
 
-
 beforeEach(() => {
   mockWS.mockReturnValue({
     poseData: null,
-    status: 'open',
+    status: "open",
     error: null,
     close: jest.fn(),
     send: jest.fn(),
   });
   origDevicePixelRatio = (window as any).devicePixelRatio;
-  Object.defineProperty(window, 'devicePixelRatio', {
+  Object.defineProperty(window, "devicePixelRatio", {
     configurable: true,
     value: 2,
   });
-  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+  Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
     configurable: true,
     value: function () {
       return {
@@ -53,7 +52,7 @@ beforeEach(() => {
     },
   });
   mockToBlob = jest.fn();
-  Object.defineProperty(HTMLCanvasElement.prototype, 'toBlob', {
+  Object.defineProperty(HTMLCanvasElement.prototype, "toBlob", {
     configurable: true,
     value: (...args: unknown[]) => {
       const [cb] = args as [(b: Blob) => void];
@@ -76,7 +75,7 @@ afterEach(() => {
   if (origDevicePixelRatio === undefined) {
     delete (window as any).devicePixelRatio;
   } else {
-    Object.defineProperty(window, 'devicePixelRatio', {
+    Object.defineProperty(window, "devicePixelRatio", {
       configurable: true,
       value: origDevicePixelRatio,
     });
@@ -106,19 +105,19 @@ class FakeStream {
 function mockMedia() {
   const stream = new FakeStream() as unknown as MediaStream;
   const getUserMedia = jest.fn().mockResolvedValue(stream);
-  Object.defineProperty(navigator, 'mediaDevices', {
+  Object.defineProperty(navigator, "mediaDevices", {
     value: { getUserMedia },
     configurable: true,
   });
   return { stream, getUserMedia };
 }
 
-test('assigns webcam stream to video element', async () => {
+test("assigns webcam stream to video element", async () => {
   const { stream, getUserMedia } = mockMedia();
-  const PoseViewer = require('../components/PoseViewer').default;
+  const PoseViewer = require("../components/PoseViewer").default;
   const { container } = render(<PoseViewer />);
   await waitFor(() => {
-    const video = container.querySelector('video') as HTMLVideoElement;
+    const video = container.querySelector("video") as HTMLVideoElement;
     expect(video.srcObject).toBe(stream);
   });
   expect(getUserMedia).toHaveBeenCalledWith({
@@ -126,32 +125,33 @@ test('assigns webcam stream to video element', async () => {
   });
 });
 
-test('canvas matches video dimensions after metadata loads', async () => {
+test("canvas matches video dimensions after metadata loads", async () => {
   const { stream } = mockMedia();
   const origRect = HTMLVideoElement.prototype.getBoundingClientRect;
-  HTMLVideoElement.prototype.getBoundingClientRect = () => ({
-    width: 320,
-    height: 240,
-  } as DOMRect);
-  const PoseViewer = require('../components/PoseViewer').default;
+  HTMLVideoElement.prototype.getBoundingClientRect = () =>
+    ({
+      width: 320,
+      height: 240,
+    }) as DOMRect;
+  const PoseViewer = require("../components/PoseViewer").default;
   const { container } = render(<PoseViewer />);
-  const video = container.querySelector('video') as HTMLVideoElement;
-  const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+  const video = container.querySelector("video") as HTMLVideoElement;
+  const canvas = container.querySelector("canvas") as HTMLCanvasElement;
   await waitFor(() => {
     expect(video.srcObject).toBe(stream);
   });
-  fireEvent(video, new Event('loadedmetadata'));
-  window.dispatchEvent(new Event('resize'));
+  fireEvent(video, new Event("loadedmetadata"));
+  window.dispatchEvent(new Event("resize"));
   await waitFor(() => {
     expect(canvas.width).toBe(640);
     expect(canvas.height).toBe(480);
-    const panel = container.querySelector('.metrics-panel');
-    expect(panel?.textContent).toContain('Camera input: 640×360');
+    const panel = container.querySelector(".metrics-panel");
+    expect(panel?.textContent).toContain("Camera input: 640×360");
   });
   HTMLVideoElement.prototype.getBoundingClientRect = origRect;
 });
 
-test('mirrors context when video transform flips horizontally', async () => {
+test("mirrors context when video transform flips horizontally", async () => {
   const { stream } = mockMedia();
   const ctx: any = {
     canvas: null,
@@ -172,7 +172,7 @@ test('mirrors context when video transform flips horizontally', async () => {
     translate: jest.fn(),
   };
   const origGetContext = HTMLCanvasElement.prototype.getContext;
-  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+  Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
     configurable: true,
     value: function () {
       ctx.canvas = this as HTMLCanvasElement;
@@ -180,31 +180,49 @@ test('mirrors context when video transform flips horizontally', async () => {
     },
   });
   const origRect = HTMLVideoElement.prototype.getBoundingClientRect;
-  HTMLVideoElement.prototype.getBoundingClientRect = () => ({
-    width: 100,
-    height: 50,
-  } as DOMRect);
+  HTMLVideoElement.prototype.getBoundingClientRect = () =>
+    ({
+      width: 100,
+      height: 50,
+    }) as DOMRect;
   let setPose: (p: any) => void = () => {};
   mockWS.mockImplementation(() => {
-    const [poseData, setData] = require('react').useState(null);
+    const [poseData, setData] = require("react").useState(null);
     setPose = setData;
-    return { poseData, status: 'open', error: null, close: jest.fn(), send: jest.fn() };
+    return {
+      poseData,
+      status: "open",
+      error: null,
+      close: jest.fn(),
+      send: jest.fn(),
+    };
   });
   const spy = jest
-    .spyOn(window, 'getComputedStyle')
-    .mockReturnValue({ transform: 'matrix(-1, 0, 0, 1, 0, 0)' } as CSSStyleDeclaration);
-  const PoseViewer = require('../components/PoseViewer').default;
+    .spyOn(window, "getComputedStyle")
+    .mockReturnValue({
+      transform: "matrix(-1, 0, 0, 1, 0, 0)",
+    } as CSSStyleDeclaration);
+  const PoseViewer = require("../components/PoseViewer").default;
   const { container } = render(<PoseViewer />);
-  const video = container.querySelector('video') as HTMLVideoElement;
+  const video = container.querySelector("video") as HTMLVideoElement;
   await waitFor(() => {
     expect(video.srcObject).toBe(stream);
   });
-  Object.defineProperty(video, 'videoWidth', { value: 100 });
-  Object.defineProperty(video, 'videoHeight', { value: 50 });
-  fireEvent(video, new Event('loadedmetadata'));
-  window.dispatchEvent(new Event('resize'));
-  require('@testing-library/react').act(() => {
-    setPose({ landmarks: [], metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0, fps: 0 } });
+  Object.defineProperty(video, "videoWidth", { value: 100 });
+  Object.defineProperty(video, "videoHeight", { value: 50 });
+  fireEvent(video, new Event("loadedmetadata"));
+  window.dispatchEvent(new Event("resize"));
+  require("@testing-library/react").act(() => {
+    setPose({
+      landmarks: [],
+      metrics: {
+        balance: 0,
+        pose_class: "",
+        knee_angle: 0,
+        posture_angle: 0,
+        fps: 0,
+      },
+    });
   });
   await waitFor(() => {
     expect(ctx.translate).toHaveBeenCalledWith(100, 0);
@@ -214,14 +232,14 @@ test('mirrors context when video transform flips horizontally', async () => {
     expect(call[2]).toBeCloseTo(0.3);
   });
   spy.mockRestore();
-  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+  Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
     configurable: true,
     value: origGetContext,
   });
   HTMLVideoElement.prototype.getBoundingClientRect = origRect;
 });
 
-test('scales context when rect size differs from video size', async () => {
+test("scales context when rect size differs from video size", async () => {
   const { stream } = mockMedia();
   const ctx: any = {
     canvas: null,
@@ -242,7 +260,7 @@ test('scales context when rect size differs from video size', async () => {
     translate: jest.fn(),
   };
   const origGetContext = HTMLCanvasElement.prototype.getContext;
-  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+  Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
     configurable: true,
     value: function () {
       ctx.canvas = this as HTMLCanvasElement;
@@ -250,29 +268,45 @@ test('scales context when rect size differs from video size', async () => {
     },
   });
   const origRect = HTMLVideoElement.prototype.getBoundingClientRect;
-  HTMLVideoElement.prototype.getBoundingClientRect = () => ({
-    width: 100,
-    height: 50,
-  } as DOMRect);
+  HTMLVideoElement.prototype.getBoundingClientRect = () =>
+    ({
+      width: 100,
+      height: 50,
+    }) as DOMRect;
   let setPose: (p: any) => void = () => {};
   mockWS.mockImplementation(() => {
-    const [poseData, setData] = require('react').useState(null);
+    const [poseData, setData] = require("react").useState(null);
     setPose = setData;
-    return { poseData, status: 'open', error: null, close: jest.fn(), send: jest.fn() };
+    return {
+      poseData,
+      status: "open",
+      error: null,
+      close: jest.fn(),
+      send: jest.fn(),
+    };
   });
-  const PoseViewer = require('../components/PoseViewer').default;
+  const PoseViewer = require("../components/PoseViewer").default;
   const { container } = render(<PoseViewer />);
-  const video = container.querySelector('video') as HTMLVideoElement;
-  const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+  const video = container.querySelector("video") as HTMLVideoElement;
+  const canvas = container.querySelector("canvas") as HTMLCanvasElement;
   await waitFor(() => {
     expect(video.srcObject).toBe(stream);
   });
-  Object.defineProperty(video, 'videoWidth', { value: 400 });
-  Object.defineProperty(video, 'videoHeight', { value: 200 });
-  fireEvent(video, new Event('loadedmetadata'));
-  window.dispatchEvent(new Event('resize'));
-  require('@testing-library/react').act(() => {
-    setPose({ landmarks: [], metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0, fps: 0 } });
+  Object.defineProperty(video, "videoWidth", { value: 400 });
+  Object.defineProperty(video, "videoHeight", { value: 200 });
+  fireEvent(video, new Event("loadedmetadata"));
+  window.dispatchEvent(new Event("resize"));
+  require("@testing-library/react").act(() => {
+    setPose({
+      landmarks: [],
+      metrics: {
+        balance: 0,
+        pose_class: "",
+        knee_angle: 0,
+        posture_angle: 0,
+        fps: 0,
+      },
+    });
   });
   await waitFor(() => {
     expect(canvas.width).toBe(200);
@@ -280,81 +314,81 @@ test('scales context when rect size differs from video size', async () => {
     expect(ctx.save).toHaveBeenCalled();
     expect(ctx.scale).not.toHaveBeenCalled();
   });
-  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+  Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
     configurable: true,
     value: origGetContext,
   });
   HTMLVideoElement.prototype.getBoundingClientRect = origRect;
 });
 
-test('toggle button stops and starts the webcam', async () => {
+test("toggle button stops and starts the webcam", async () => {
   const { stream, getUserMedia } = mockMedia();
-  const PoseViewer = require('../components/PoseViewer').default;
+  const PoseViewer = require("../components/PoseViewer").default;
   const { container, getByRole } = render(<PoseViewer />);
-  const button = getByRole('button');
+  const button = getByRole("button");
 
   await waitFor(() => {
-    const video = container.querySelector('video') as HTMLVideoElement;
+    const video = container.querySelector("video") as HTMLVideoElement;
     expect(video.srcObject).toBe(stream);
   });
-  expect(button).toHaveTextContent('Stop Webcam');
+  expect(button).toHaveTextContent("Stop Webcam");
 
   fireEvent.click(button);
   await waitFor(() => {
-    const video = container.querySelector('video') as HTMLVideoElement;
+    const video = container.querySelector("video") as HTMLVideoElement;
     expect(video.srcObject).toBeFalsy();
   });
-  expect(button).toHaveTextContent('Start Webcam');
+  expect(button).toHaveTextContent("Start Webcam");
 
   fireEvent.click(button);
   await waitFor(() => {
-    const video = container.querySelector('video') as HTMLVideoElement;
+    const video = container.querySelector("video") as HTMLVideoElement;
     expect(video.srcObject).toBe(stream);
   });
   expect(getUserMedia).toHaveBeenCalledTimes(2);
 });
 
-test('stop button closes the WebSocket', async () => {
+test("stop button closes the WebSocket", async () => {
   const { stream, getUserMedia } = mockMedia();
   mockWS.mockImplementation(() => {
-    const [status, setStatus] = require('react').useState('open');
+    const [status, setStatus] = require("react").useState("open");
     return {
       poseData: null,
-      status: status as 'open' | 'closed',
+      status: status as "open" | "closed",
       error: null,
-      close: () => setStatus('closed'),
+      close: () => setStatus("closed"),
       send: jest.fn(),
     };
   });
-  const PoseViewerMod = require('../components/PoseViewer').default;
+  const PoseViewerMod = require("../components/PoseViewer").default;
   const { getByRole, getByText, container } = render(<PoseViewerMod />);
-  const button = getByRole('button');
+  const button = getByRole("button");
   await waitFor(() => {
-    const video = container.querySelector('video') as HTMLVideoElement;
+    const video = container.querySelector("video") as HTMLVideoElement;
     expect(video.srcObject).toBe(stream);
   });
-  expect(getByText('Connection: open')).toBeInTheDocument();
+  expect(getByText("Connection: open")).toBeInTheDocument();
   fireEvent.click(button);
   await waitFor(() => {
-    expect(getByText('Connection: closed')).toBeInTheDocument();
+    expect(getByText("Connection: closed")).toBeInTheDocument();
   });
   expect(getUserMedia).toHaveBeenCalled();
 });
 
-test('sends frames over WebSocket', async () => {
+test("sends frames over WebSocket", async () => {
   const { stream } = mockMedia();
   const send = jest.fn();
   let setPose: (p: any) => void = () => {};
   mockWS.mockImplementation(() => {
-    const [poseData, setData] = require('react').useState(null);
+    const [poseData, setData] = require("react").useState(null);
     setPose = setData;
-    return { poseData, status: 'open', error: null, close: jest.fn(), send };
+    return { poseData, status: "open", error: null, close: jest.fn(), send };
   });
   const origGetContext = HTMLCanvasElement.prototype.getContext;
   const origToBlob = HTMLCanvasElement.prototype.toBlob;
   const origRect = HTMLVideoElement.prototype.getBoundingClientRect;
   const rect = { width: 1, height: 1 } as { width: number; height: number };
-  Object.defineProperty(HTMLVideoElement.prototype, 'getBoundingClientRect', {
+  Object.defineProperty(HTMLVideoElement.prototype, "getBoundingClientRect", {
     configurable: true,
     value: () => rect as DOMRect,
   });
@@ -376,14 +410,14 @@ test('sends frames over WebSocket', async () => {
     restore: jest.fn(),
     translate: jest.fn(),
   };
-  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+  Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
     configurable: true,
     value: function () {
       ctx.canvas = this as HTMLCanvasElement;
       return ctx as CanvasRenderingContext2D;
     },
   });
-  Object.defineProperty(HTMLCanvasElement.prototype, 'toBlob', {
+  Object.defineProperty(HTMLCanvasElement.prototype, "toBlob", {
     configurable: true,
     value: (...args: unknown[]) => {
       const [cb] = args as [(b: Blob) => void];
@@ -392,25 +426,34 @@ test('sends frames over WebSocket', async () => {
     },
   });
 
-  const PoseViewer = require('../components/PoseViewer').default;
+  const PoseViewer = require("../components/PoseViewer").default;
   const { container } = render(<PoseViewer />);
-  const video = container.querySelector('video') as HTMLVideoElement;
-  const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+  const video = container.querySelector("video") as HTMLVideoElement;
+  const canvas = container.querySelector("canvas") as HTMLCanvasElement;
   await waitFor(() => {
     expect(video.srcObject).toBe(stream);
   });
-  Object.defineProperty(video, 'videoWidth', { value: 1 });
-  Object.defineProperty(video, 'videoHeight', { value: 1 });
-  Object.defineProperty(video, 'readyState', { value: 2 });
-  fireEvent(video, new Event('loadedmetadata'));
-  window.dispatchEvent(new Event('resize'));
-  require('@testing-library/react').act(() => {
-    setPose({ landmarks: [], metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0, fps: 0 } });
+  Object.defineProperty(video, "videoWidth", { value: 1 });
+  Object.defineProperty(video, "videoHeight", { value: 1 });
+  Object.defineProperty(video, "readyState", { value: 2 });
+  fireEvent(video, new Event("loadedmetadata"));
+  window.dispatchEvent(new Event("resize"));
+  require("@testing-library/react").act(() => {
+    setPose({
+      landmarks: [],
+      metrics: {
+        balance: 0,
+        pose_class: "",
+        knee_angle: 0,
+        posture_angle: 0,
+        fps: 0,
+      },
+    });
   });
   await waitFor(() => expect(send).toHaveBeenCalled());
   expect(mockToBlob).toHaveBeenCalledWith(
     expect.any(Function),
-    'image/jpeg',
+    "image/jpeg",
     expect.any(Number),
   );
   expect(ctx.save).toHaveBeenCalled();
@@ -418,112 +461,169 @@ test('sends frames over WebSocket', async () => {
   expect(canvas.height).toBe(2);
   rect.width = 2;
   rect.height = 2;
-  window.dispatchEvent(new Event('resize'));
-  require('@testing-library/react').act(() => {
-    setPose({ landmarks: [], metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0, fps: 0 } });
+  window.dispatchEvent(new Event("resize"));
+  require("@testing-library/react").act(() => {
+    setPose({
+      landmarks: [],
+      metrics: {
+        balance: 0,
+        pose_class: "",
+        knee_angle: 0,
+        posture_angle: 0,
+        fps: 0,
+      },
+    });
   });
-  await waitFor(() => expect(send).toHaveBeenCalledTimes(2));
-  expect(mockToBlob).toHaveBeenCalledTimes(2);
+  await waitFor(() => expect(send).toHaveBeenCalledTimes(3));
+  expect(mockToBlob).toHaveBeenCalledTimes(3);
   expect(canvas.width).toBe(4);
   expect(canvas.height).toBe(4);
   expect(send).toHaveBeenCalled();
-  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+  Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
     configurable: true,
     value: origGetContext,
   });
-  Object.defineProperty(HTMLCanvasElement.prototype, 'toBlob', {
+  Object.defineProperty(HTMLCanvasElement.prototype, "toBlob", {
     configurable: true,
     value: origToBlob,
   });
-  Object.defineProperty(HTMLVideoElement.prototype, 'getBoundingClientRect', {
+  Object.defineProperty(HTMLVideoElement.prototype, "getBoundingClientRect", {
     configurable: true,
     value: origRect,
   });
 });
 
-test('drawMs is non-negative after rendering a frame', async () => {
+test("drawMs is non-negative after rendering a frame", async () => {
   const { stream } = mockMedia();
   let setPose: (p: any) => void = () => {};
   mockWS.mockImplementation(() => {
-    const [poseData, setData] = require('react').useState(null);
+    const [poseData, setData] = require("react").useState(null);
     setPose = setData;
-    return { poseData, status: 'open', error: null, close: jest.fn(), send: jest.fn() };
+    return {
+      poseData,
+      status: "open",
+      error: null,
+      close: jest.fn(),
+      send: jest.fn(),
+    };
   });
-  const PoseViewer = require('../components/PoseViewer').default;
+  const PoseViewer = require("../components/PoseViewer").default;
   const { container } = render(<PoseViewer />);
-  const video = container.querySelector('video') as HTMLVideoElement;
+  const video = container.querySelector("video") as HTMLVideoElement;
   await waitFor(() => {
     expect(video.srcObject).toBe(stream);
   });
-  Object.defineProperty(video, 'videoWidth', { value: 100 });
-  Object.defineProperty(video, 'videoHeight', { value: 50 });
-  fireEvent(video, new Event('loadedmetadata'));
-  window.dispatchEvent(new Event('resize'));
-  require('@testing-library/react').act(() => {
-    setPose({ landmarks: [], metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0, fps: 0 } });
+  Object.defineProperty(video, "videoWidth", { value: 100 });
+  Object.defineProperty(video, "videoHeight", { value: 50 });
+  fireEvent(video, new Event("loadedmetadata"));
+  window.dispatchEvent(new Event("resize"));
+  require("@testing-library/react").act(() => {
+    setPose({
+      landmarks: [],
+      metrics: {
+        balance: 0,
+        pose_class: "",
+        knee_angle: 0,
+        posture_angle: 0,
+        fps: 0,
+      },
+    });
   });
   await waitFor(() => {
-    const panel = container.querySelector('.metrics-panel') as HTMLElement;
-    const drawEl = Array.from(panel.querySelectorAll('p')).find((p) =>
-      p.textContent?.startsWith('Draw:')
+    const panel = container.querySelector(".metrics-panel") as HTMLElement;
+    const drawEl = Array.from(panel.querySelectorAll("p")).find((p) =>
+      p.textContent?.startsWith("Draw:"),
     );
     expect(drawEl).toBeTruthy();
-    const value = parseFloat(drawEl!.textContent!.replace(/[^0-9.-]/g, ''));
+    const value = parseFloat(drawEl!.textContent!.replace(/[^0-9.-]/g, ""));
     expect(value).toBeGreaterThanOrEqual(0);
   });
 });
 
-test('skips drawing when page is hidden', async () => {
+test("skips drawing when page is hidden", async () => {
   const { stream } = mockMedia();
   let setPose: (p: any) => void = () => {};
   mockWS.mockImplementation(() => {
-    const [poseData, setData] = require('react').useState(null);
+    const [poseData, setData] = require("react").useState(null);
     setPose = setData;
-    return { poseData, status: 'open', error: null, close: jest.fn(), send: jest.fn() };
+    return {
+      poseData,
+      status: "open",
+      error: null,
+      close: jest.fn(),
+      send: jest.fn(),
+    };
   });
   const origHidden = document.hidden;
-  Object.defineProperty(document, 'hidden', { configurable: true, value: true });
-  const PoseViewer = require('../components/PoseViewer').default;
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    value: true,
+  });
+  const PoseViewer = require("../components/PoseViewer").default;
   const { container } = render(<PoseViewer />);
-  const video = container.querySelector('video') as HTMLVideoElement;
+  const video = container.querySelector("video") as HTMLVideoElement;
   await waitFor(() => {
     expect(video.srcObject).toBe(stream);
   });
-  Object.defineProperty(video, 'videoWidth', { value: 100 });
-  Object.defineProperty(video, 'videoHeight', { value: 50 });
-  fireEvent(video, new Event('loadedmetadata'));
-  window.dispatchEvent(new Event('resize'));
-  require('@testing-library/react').act(() => {
-    setPose({ landmarks: [], metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0, fps: 0 } });
+  Object.defineProperty(video, "videoWidth", { value: 100 });
+  Object.defineProperty(video, "videoHeight", { value: 50 });
+  fireEvent(video, new Event("loadedmetadata"));
+  window.dispatchEvent(new Event("resize"));
+  require("@testing-library/react").act(() => {
+    setPose({
+      landmarks: [],
+      metrics: {
+        balance: 0,
+        pose_class: "",
+        knee_angle: 0,
+        posture_angle: 0,
+        fps: 0,
+      },
+    });
   });
   await waitFor(() => {
     expect(mockDraw).not.toHaveBeenCalled();
   });
-  Object.defineProperty(document, 'hidden', { configurable: true, value: origHidden });
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    value: origHidden,
+  });
 });
 
-test('draws when highest visibility is 0.4', async () => {
+test("draws when highest visibility is 0.4", async () => {
   const { stream } = mockMedia();
   let setPose: (p: any) => void = () => {};
   mockWS.mockImplementation(() => {
-    const [poseData, setData] = require('react').useState(null);
+    const [poseData, setData] = require("react").useState(null);
     setPose = setData;
-    return { poseData, status: 'open', error: null, close: jest.fn(), send: jest.fn() };
+    return {
+      poseData,
+      status: "open",
+      error: null,
+      close: jest.fn(),
+      send: jest.fn(),
+    };
   });
-  const PoseViewer = require('../components/PoseViewer').default;
+  const PoseViewer = require("../components/PoseViewer").default;
   const { container } = render(<PoseViewer />);
-  const video = container.querySelector('video') as HTMLVideoElement;
+  const video = container.querySelector("video") as HTMLVideoElement;
   await waitFor(() => {
     expect(video.srcObject).toBe(stream);
   });
-  Object.defineProperty(video, 'videoWidth', { value: 100 });
-  Object.defineProperty(video, 'videoHeight', { value: 50 });
-  fireEvent(video, new Event('loadedmetadata'));
-  window.dispatchEvent(new Event('resize'));
-  require('@testing-library/react').act(() => {
+  Object.defineProperty(video, "videoWidth", { value: 100 });
+  Object.defineProperty(video, "videoHeight", { value: 50 });
+  fireEvent(video, new Event("loadedmetadata"));
+  window.dispatchEvent(new Event("resize"));
+  require("@testing-library/react").act(() => {
     setPose({
       landmarks: [{ x: 0, y: 0, visibility: 0.4 }],
-      metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0, fps: 0 },
+      metrics: {
+        balance: 0,
+        pose_class: "",
+        knee_angle: 0,
+        posture_angle: 0,
+        fps: 0,
+      },
     });
   });
   await waitFor(() => {
@@ -533,32 +633,41 @@ test('draws when highest visibility is 0.4', async () => {
   });
 });
 
-test('drops frames during backend delay', async () => {
+test("drops frames during backend delay", async () => {
   jest.useFakeTimers();
   const { stream } = mockMedia();
   const send = jest.fn();
   let setPose: (p: any) => void = () => {};
   mockWS.mockImplementation(() => {
-    const [poseData, setData] = require('react').useState(null);
+    const [poseData, setData] = require("react").useState(null);
     setPose = setData;
-    return { poseData, status: 'open', error: null, close: jest.fn(), send };
+    return { poseData, status: "open", error: null, close: jest.fn(), send };
   });
-  const PoseViewer = require('../components/PoseViewer').default;
+  const PoseViewer = require("../components/PoseViewer").default;
   const { container } = render(<PoseViewer />);
-  const video = container.querySelector('video') as HTMLVideoElement;
+  const video = container.querySelector("video") as HTMLVideoElement;
   await waitFor(() => {
     expect(video.srcObject).toBe(stream);
   });
-  Object.defineProperty(video, 'videoWidth', { value: 1 });
-  Object.defineProperty(video, 'videoHeight', { value: 1 });
-  Object.defineProperty(video, 'readyState', { value: 2 });
-  fireEvent(video, new Event('loadedmetadata'));
-  window.dispatchEvent(new Event('resize'));
+  Object.defineProperty(video, "videoWidth", { value: 1 });
+  Object.defineProperty(video, "videoHeight", { value: 1 });
+  Object.defineProperty(video, "readyState", { value: 2 });
+  fireEvent(video, new Event("loadedmetadata"));
+  window.dispatchEvent(new Event("resize"));
   await waitFor(() => expect(send).toHaveBeenCalledTimes(1));
   jest.advanceTimersByTime(200);
   expect(send).toHaveBeenCalledTimes(1);
-  require('@testing-library/react').act(() => {
-    setPose({ landmarks: [], metrics: { balance: 0, pose_class: '', knee_angle: 0, posture_angle: 0, fps: 0 } });
+  require("@testing-library/react").act(() => {
+    setPose({
+      landmarks: [],
+      metrics: {
+        balance: 0,
+        pose_class: "",
+        knee_angle: 0,
+        posture_angle: 0,
+        fps: 0,
+      },
+    });
   });
   await waitFor(() => expect(send).toHaveBeenCalledTimes(2));
   jest.useRealTimers();

--- a/frontend/src/components/PoseViewer.tsx
+++ b/frontend/src/components/PoseViewer.tsx
@@ -255,7 +255,14 @@ const PoseViewer: React.FC = () => {
     const end = performance.now();
     setDrawMs(end - start);
     setLatencyMs(Date.now() - tsSendRef.current);
-    requestAnimationFrame(captureAndSend);
+    const inferMs = Number((poseData.metrics as any).infer_ms ?? 0);
+    const targetDelay = inferMs + encodeMs + 5;
+    const elapsed = Date.now() - tsSendRef.current;
+    const waitMs = Math.max(0, targetDelay - elapsed);
+    const id = window.setTimeout(() => {
+      requestAnimationFrame(captureAndSend);
+    }, waitMs);
+    return () => clearTimeout(id);
   }, [poseData]);
 
   const baseMetrics: PoseMetrics = {

--- a/tests/performance/test_client_fps.py
+++ b/tests/performance/test_client_fps.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+import asyncio
+import json
+import struct
+import time
+from typing import Any
+
+import numpy as np
+import pytest
+
+import backend.server as server
+
+
+class SlowPose:
+    def process(self, frame: Any) -> list[dict[str, float]]:
+        time.sleep(0.035)
+        return [{"x": 0.0, "y": 0.0, "visibility": 1.0}] * 17
+
+    def close(self) -> None:
+        pass
+
+
+class QueueWS:
+    def __init__(self) -> None:
+        self.accepted = False
+        self.sent: list[str] = []
+        self.queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def receive_bytes(self) -> bytes:
+        data = await self.queue.get()
+        if data is None:
+            raise server.WebSocketDisconnect()
+        return data
+
+    async def send_text(self, text: str) -> None:
+        self.sent.append(text)
+
+    async def close(self) -> None:
+        pass
+
+
+async def _slow_process(det: SlowPose, frame: Any) -> list[dict[str, float]]:
+    return det.process(frame)
+
+
+async def _run_sim(duration: float) -> float:
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(server, "PoseDetector", lambda *_a, **_k: SlowPose())
+    monkeypatch.setattr(server, "_process", _slow_process)
+    frame = np.zeros((1, 1, 3), dtype=np.uint8)
+    _, buf = server.cv2.imencode(".jpg", frame)
+    header = struct.pack("<dHH", 0.0, 1, 1)
+    ws = QueueWS()
+    server_task = asyncio.create_task(server.pose_endpoint(ws))
+    encode_ms = 2.0
+    await ws.queue.put(header + buf.tobytes())
+    send_times = [time.perf_counter()]
+    recv_idx = 0
+    start = time.perf_counter()
+    try:
+        while time.perf_counter() - start < duration:
+            while len(ws.sent) <= recv_idx:
+                await asyncio.sleep(0.001)
+            metrics = json.loads(ws.sent[recv_idx])["metrics"]
+            infer_ms = float(metrics.get("infer_ms", 0))
+            elapsed = time.perf_counter() - send_times[-1]
+            target = (infer_ms + encode_ms + 5) / 1000.0
+            await asyncio.sleep(max(0.0, target - elapsed))
+            await ws.queue.put(header + buf.tobytes())
+            send_times.append(time.perf_counter())
+            recv_idx += 1
+    finally:
+        await ws.queue.put(None)
+        await server_task
+        monkeypatch.undo()
+    return (len(send_times) - 1) / (send_times[-1] - send_times[0])
+
+
+def test_client_fps_stabilises() -> None:
+    fps = asyncio.run(_run_sim(10.0))
+    assert 23.0 <= fps <= 25.0


### PR DESCRIPTION
## Summary
- slow down captures until the last frame's inference and encode time passes
- update PoseViewer tests for new frame throttling
- verify 24 FPS stability with a new performance test
- document capture delay logic in NOTES and TODO

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6887223c8a6c8325975b17d7080348f0