### PR TITLE
Centralize camera resize constant

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -2078,3 +2078,8 @@ landmarks are missing.
 - **Motivation / Decision**: adapt capture rate to inference latency
   to stabilize FPS.
 - **Next step**: none.
+\n### 2025-07-28  PR #NOTSET
+- **Summary**: centralised frame resize constant as
+  backend.config.CAM_TARGET_RES and updated tests/docs.
+- **Stage**: implementation
+- **Motivation / Decision**: avoid magic number, clarify docs.

--- a/README.md
+++ b/README.md
@@ -188,8 +188,9 @@ surrounding
 
 Webcam capture defaults to **640×360** to keep bandwidth low. Before
 running inference the backend resizes each frame so its larger side is
-`256` px. This value comes from the `CAM_TARGET_RES` constant which can
-be increased for higher accuracy at the cost of speed.
+`256` px. This value comes from the `backend.config.CAM_TARGET_RES`
+constant which can be increased for higher accuracy at the cost of
+speed.
 
 `.pose-container` is styled so the canvas and video stack on top of each other.
 `MetricsPanel` is rendered as a sibling after this container so the metrics list

--- a/backend/config.py
+++ b/backend/config.py
@@ -4,3 +4,6 @@ from __future__ import annotations
 
 VISIBILITY_MIN = 0.50
 """Minimum visibility score for pose landmarks."""
+
+CAM_TARGET_RES = 256
+"""Target resolution for resizing camera frames."""

--- a/backend/pose_detector.py
+++ b/backend/pose_detector.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import cv2
 import mediapipe as mp
 import numpy as np
+from backend.config import CAM_TARGET_RES
 
 
 class PoseDetector:
@@ -44,7 +45,7 @@ class PoseDetector:
             raise ValueError("frame is None")
         rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         h, w = rgb.shape[:2]
-        scale = 256 / max(h, w)
+        scale = CAM_TARGET_RES / max(h, w)
         size = (int(round(w * scale)), int(round(h * scale)))
         resized = cv2.resize(rgb, size, interpolation=cv2.INTER_AREA)
         results = self._pose.process(resized)

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,8 +27,8 @@ JSON. The metrics are calculated in `backend/analytics.py`:
 
 Webcam capture defaults to **640×360** so images stay small. Before
 running inference the backend resizes each frame to `256` px using the
-`CAM_TARGET_RES` constant. Increase this value for higher accuracy if the
-extra processing time is acceptable.
+`backend.config.CAM_TARGET_RES` constant. Increase this value for higher
+accuracy if the extra processing time is acceptable.
 
 ```python
 from backend.analytics import extract_pose_metrics

--- a/docs/source/README.md
+++ b/docs/source/README.md
@@ -27,8 +27,8 @@ JSON. The metrics are calculated in `backend/analytics.py`:
 
 Webcam capture defaults to **640×360** so images stay small. Before
 running inference the backend resizes each frame to `256` px using the
-`CAM_TARGET_RES` constant. Increase this value for higher accuracy if the
-extra processing time is acceptable.
+`backend.config.CAM_TARGET_RES` constant. Increase this value for higher
+accuracy if the extra processing time is acceptable.
 
 ```python
 from backend.analytics import extract_pose_metrics

--- a/tests/backend/test_config.py
+++ b/tests/backend/test_config.py
@@ -5,3 +5,7 @@ from backend import config
 
 def test_visibility_min_constant() -> None:
     assert config.VISIBILITY_MIN == 0.50
+
+
+def test_cam_target_res_constant() -> None:
+    assert config.CAM_TARGET_RES == 256

--- a/tests/backend/test_pose_detector.py
+++ b/tests/backend/test_pose_detector.py
@@ -4,7 +4,7 @@ import types
 import numpy as np
 import backend.pose_detector as pd
 import backend.server as srv
-from backend.config import VISIBILITY_MIN
+from backend.config import CAM_TARGET_RES, VISIBILITY_MIN
 import mediapipe as mp
 
 
@@ -158,5 +158,5 @@ def test_process_resizes_frame(monkeypatch):
     det = pd.PoseDetector()
     frame = np.zeros((480, 640, 3), dtype=np.uint8)
     det.process(frame)
-    assert max(CaptureSizePose.shape[:2]) == 256
+    assert max(CaptureSizePose.shape[:2]) == CAM_TARGET_RES
     assert CaptureSizePose.shape[2] == 3


### PR DESCRIPTION
## Summary
- define `CAM_TARGET_RES` in `backend.config`
- use constant inside `PoseDetector`
- reference constant in tests
- document `backend.config.CAM_TARGET_RES` in README and docs

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6887296493208325936f3ec6f014d95a