### PR TITLE
docs: log camera resolution metric

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -2078,3 +2078,10 @@ landmarks are missing.
 - **Motivation / Decision**: adapt capture rate to inference latency
   to stabilize FPS.
 - **Next step**: none.
+
+### 2025-07-28  PR #272
+
+- **Summary**: metrics panel now shows camera width and height with tests.
+- **Stage**: implementation
+- **Motivation / Decision**: expose camera resolution in UI; tests added.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -227,6 +227,6 @@
       use a median visibility threshold.
 - [x] Replace NaN metrics with null when serializing WebSocket payloads.
 - [x] Scale captured frames before encoding and compress with JPEG quality 0.55.
-- [ ] Show camera input resolution in the Metrics panel.
+- [x] Show camera input resolution in the Metrics panel.
 - [x] Prepend width and height to WebSocket frame header for debugging.
 - [x] Delay next frame capture by infer_ms + encodeMs + 5 ms.


### PR DESCRIPTION
## Summary
- mark TODO on camera input resolution metric
- note that metrics panel shows camera width and height with tests

## Testing
- `make lint-docs`
- `make update-todo-date`


------
https://chatgpt.com/codex/tasks/task_e_68872964dbe88325b4d58e35a6709ac0