### PR TITLE
Fix FPS scheduling logic

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -2092,3 +2092,13 @@ landmarks are missing.
   backend.config.CAM_TARGET_RES and updated tests/docs.
 - **Stage**: implementation
 - **Motivation / Decision**: avoid magic number, clarify docs.
+
+-### 2025-07-28
+
+- **Summary**: revised frame capture timing in PoseViewer. Use rAF for short
+  delays and update encodePending logic. Performance test now expects at least
+  22fps.
+- **Stage**: implementation
+- **Motivation / Decision**: prevent rAF nesting overhead and stabilise FPS when
+  infer_ms and encode_ms are small.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -230,3 +230,4 @@
 - [x] Show camera input resolution in the Metrics panel.
 - [x] Prepend width and height to WebSocket frame header for debugging.
 - [x] Delay next frame capture by infer_ms + encodeMs + 5 ms.
+- [x] Capture scheduling uses setTimeout when delay >= 16ms and rAF otherwise.


### PR DESCRIPTION
## Summary
- use requestAnimationFrame for short frame delays
- clear encodePending earlier
- expect 22fps or more in client performance test
- note FPS fix in TODO and NOTES

## Testing
- `make lint`
- `make typecheck`
- `make typecheck-ts`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68873838d01483259941ed8a52baf3d2